### PR TITLE
select free port for webui by gradio

### DIFF
--- a/webui_train.py
+++ b/webui_train.py
@@ -249,4 +249,4 @@ if __name__ == "__main__":
         style_gen_btn.click(style_gen, inputs=[model_name], outputs=[info])
         train_btn.click(train, inputs=[model_name], outputs=[info])
 
-    app.launch(share=False, server_port=7860, inbrowser=True)
+    app.launch(share=False, inbrowser=True)


### PR DESCRIPTION
## Abstract/Background

gradioがport番号を7860-8860の未使用に割り当てる。
https://github.com/gradio-app/gradio/blob/24a583688046867ca8b8b02959c441818bdb34a2/js/preview/src/index.ts#L42

先にApp.batを立ち上げて7860を使われると、Train.batがport指定のため落ちてしまう。

## Solution

特にtrainのport番号指定のモチベーションがなければ自動でいいのかなと思いました。
本家のUIが7860指定かと思いますので、（ぱっと見は合わせても恩恵なさそうかなと思ったので消してみましたが、）意図があっての指定であれば却下ください。