### PR TITLE
Fix: normalize argument error slice

### DIFF
--- a/default_style.py
+++ b/default_style.py
@@ -7,7 +7,7 @@ import json
 
 
 def set_style_config(json_path, output_path):
-    with open(json_path, "r") as f:
+    with open(json_path, "r", encoding="utf-8") as f:
         json_dict = json.load(f)
     json_dict["data"]["num_styles"] = 1
     json_dict["data"]["style2id"] = {DEFAULT_STYLE: 0}

--- a/slice.py
+++ b/slice.py
@@ -7,6 +7,7 @@ import torch
 from tqdm import tqdm
 
 from common.stdout_wrapper import SAFE_STDOUT
+from resample import normalize_audio
 
 vad_model, utils = torch.hub.load(
     repo_or_dir="snakers4/silero-vad",
@@ -44,7 +45,7 @@ def get_stamps(audio_file, min_silence_dur_ms=700, min_sec=2):
 
 
 def split_wav(
-    audio_file, target_dir="raw", max_sec=12, min_silence_dur_ms=700, min_sec=2
+    audio_file, target_dir="raw", max_sec=12, min_silence_dur_ms=700, min_sec=2, normalize=False
 ):
     margin = 200  # ミリ秒単位で、音声の前後に余裕を持たせる
     upper_bound_ms = max_sec * 1000  # これ以上の長さの音声は無視する
@@ -89,6 +90,7 @@ if __name__ == "__main__":
     parser.add_argument("--min_silence_dur_ms", "-s", type=int, default=700)
     parser.add_argument("--input_dir", "-i", type=str, default="inputs")
     parser.add_argument("--output_dir", "-t", type=str, default="raw")
+    parser.add_argument("--normalize", action="store_true")
     args = parser.parse_args()
 
     input_dir = args.input_dir
@@ -96,6 +98,7 @@ if __name__ == "__main__":
     min_sec = args.min_sec
     max_sec = args.max_sec
     min_silence_dur_ms = args.min_silence_dur_ms
+    normalize = args.normalize
 
     wav_files = [
         os.path.join(input_dir, f)
@@ -114,6 +117,7 @@ if __name__ == "__main__":
             max_sec=max_sec,
             min_sec=min_sec,
             min_silence_dur_ms=min_silence_dur_ms,
+            normalize=normalize
         )
         total_sec += time_sec
 


### PR DESCRIPTION
`python webui_dataset.py`を実行した際にslice.pyでnormalize変数が見つからないエラーが起きていたので修正しました。

あと`python webui_train.py`実行時に下記のエラーが起きたので修正しました。もしかしたら環境依存の可能性もあるのですが、よろしくお願いいたします。

```
Traceback (most recent call last):
  File "C:\Users\shout\dev\Style-Bert-VITS2\train_ms.py", line 811, in <module>
    run()
  File "C:\Users\shout\dev\Style-Bert-VITS2\train_ms.py", line 147, in run
    default_style.set_style_config(args.config, os.path.join(out_dir, "config.json"))
  File "C:\Users\shout\dev\Style-Bert-VITS2\default_style.py", line 11, in set_style_config
    json_dict = json.load(f)
  File "C:\Users\shout\AppData\Local\Programs\Python\Python310\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'cp932' codec can't decode byte 0x83 in position 37: illegal multibyte sequence
```