### PR TITLE
並列処理中のエラー情報の強化

### DIFF
--- a/style_gen.py
+++ b/style_gen.py
@@ -19,12 +19,13 @@ device = torch.device(config.style_gen_config.device)
 inference.to(device)
 
 
-def extract_style_vector(wav_path):
-    return inference(wav_path)
-
-
 def save_style_vector(wav_path):
-    style_vec = extract_style_vector(wav_path)
+    try:
+        style_vec = inference(wav_path)
+    except Exception as e:
+        print(f"\nIncluding any problems: {wav_path}")
+        print(e)
+        raise
     np.save(f"{wav_path}.npy", style_vec)  # `test.wav` -> `test.wav.npy`
     return style_vec
 


### PR DESCRIPTION
## 概要

並列実行中のエラー終了時の原因調査を楽にしたい。

この例では学習の前処理で、Aivisなりリッチなdatasetツールにより最終的にほぼ0byteになった音源が混じり、それがstyle_genまで気付かれずに処理されて落ちている。
```
Traceback (most recent call last):
  File "D:\Style-Bert-VITS2\style_gen.py", line 63, in <module>
    list(
  File "D:\Style-Bert-VITS2\venv\lib\site-packages\tqdm\std.py", line 1182, in __iter__
    for obj in iterable:
（中略）
  File "D:\Style-Bert-VITS2\venv\lib\site-packages\torchaudio\functional\functional.py", line 1460, in _apply_sinc_resample_kernel
    waveform = waveform.view(-1, shape[-1])
RuntimeError: cannot reshape tensor of 0 elements into shape [-1, 0] because the unspecified dimension size -1 can be any value and is ambiguous
```

この例だけだと、その音源を削除してesd.listからも削除してあげるとベストだけど、
その処理も大変だし、他の要因のRuntimeErrorが出る可能性もありうるから、一概に何かするのは危険そう。

現状はどの音源が原因だったかわからないので、せめてそのログだけでもほしいです。

## 変更後

この直しだとバーに続いて表示される可能性があるのでベストじゃないですが、

```
███████|
Including any problems: Data/x/wavs/y.wav 
cannot reshape tensor of 0 elements into shape [-1, 0] because the unspecified dimension size -1 can be any value and is ambiguous
```