### PR TITLE
speech_mos.pyが出力するCSVにBOMを追加

### DIFF
--- a/speech_mos.py
+++ b/speech_mos.py
@@ -99,7 +99,7 @@ for model_file, step, scores in results:
     logger.info(f"{model_file}: {scores[-1]}")
 
 with open(
-    mos_result_dir / f"mos_{model_name}.csv", "w", encoding="utf-8", newline=""
+    mos_result_dir / f"mos_{model_name}.csv", "w", encoding="utf_8_sig", newline=""
 ) as f:
     writer = csv.writer(f)
     writer.writerow(["model_path"] + ["step"] + test_texts + ["mean"])


### PR DESCRIPTION
speech_mos.pyが出力するCSVファイルにBOMを追加しました。
これは、日本語を含む文字コードUTF-8形式のCSVファイルをMicrosoft Excelで直接開いた際に、BOMが設定されていないと文字化けが発生する問題への対応です。