### PR TITLE
Fix AttributeError by adding missing 'repo_id' to HParams

### DIFF
--- a/train_ms.py
+++ b/train_ms.py
@@ -131,6 +131,7 @@ def run():
     # This is needed because we have to pass values to `train_and_evaluate()`
     hps.model_dir = model_dir
     hps.speedup = args.speedup
+    hps.repo_id = args.repo_id
 
     # 比较路径是否相同
     if os.path.realpath(args.config) != os.path.realpath(


### PR DESCRIPTION
I tried to train English TTS models via train_ms.py, but the error occured whether I gave `--repo_id` as a parameter or not.

1. when `--repo_id` provided
```python
Traceback (most recent call last):
  File "/workspace/Style-Bert-VITS2/train_ms.py", line 169, in run
    repo_id=hps.repo_id,
AttributeError: 'HParams' object has no attribute 'repo_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/Style-Bert-VITS2/train_ms.py", line 950, in <module>
    run()
  File "/workspace/Style-Bert-VITS2/train_ms.py", line 174, in run
    f"Failed to upload files to the repo {hps.repo_id}. Please check if the repo exists and you have logged in using `huggingface-cli login`."
AttributeError: 'HParams' object has no attribute 'repo_id'
```

2. `--repo_id` not provided
```python
Traceback (most recent call last):
  File "/workspace/Style-Bert-VITS2/train_ms.py", line 950, in <module>
    run()
  File "/workspace/Style-Bert-VITS2/train_ms.py", line 449, in run
    train_and_evaluate(
  File "/workspace/Style-Bert-VITS2/train_ms.py", line 819, in train_and_evaluate
    if hps.repo_id is not None:
AttributeError: 'HParams' object has no attribute 'repo_id'
Epoch 20(22%)/100:  19%|██████████████████▎
```

found out that the attribute `repo_id` was missing for `hps`, so added a line of code.