### PR TITLE
複数プロセス利用時にユーザー辞書を活用するためのpyopenjtalk別プロセス化

### DIFF
--- a/common/subprocess_utils.py
+++ b/common/subprocess_utils.py
@@ -14,6 +14,7 @@ def run_script_with_log(cmd: list[str], ignore_warning=False) -> tuple[bool, str
         stdout=SAFE_STDOUT,  # type: ignore
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8",
     )
     if result.returncode != 0:
         logger.error(f"Error: {' '.join(cmd)}\n{result.stderr}")

--- a/preprocess_text.py
+++ b/preprocess_text.py
@@ -7,10 +7,10 @@ from typing import Optional
 import click
 from tqdm import tqdm
 
+from common.log import logger
+from common.stdout_wrapper import SAFE_STDOUT
 from config import config
 from text.cleaner import clean_text
-from common.stdout_wrapper import SAFE_STDOUT
-from common.log import logger
 
 preprocess_text_config = config.preprocess_text_config
 
@@ -89,7 +89,10 @@ def preprocess(
                             )
                         )
                     except Exception as e:
-                        logger.error(f"An error occurred at line:\n{line.strip()}\n{e}")
+                        logger.error(
+                            f"An error occurred at line:\n{line.strip()}\n{e}",
+                            encoding="utf-8",
+                        )
                         with open(error_log_path, "a", encoding="utf-8") as error_log:
                             error_log.write(f"{line.strip()}\n{e}\n\n")
                         error_count += 1
@@ -172,8 +175,9 @@ def preprocess(
                 f"An error occurred in {error_count} lines. Please check {error_log_path} for details."
             )
             raise Exception(
-                f"An error occurred in {error_count} lines. Please check {error_log_path} for details."
+                f"An error occurred in {error_count} lines. Please check `Data/you_model_name/text_error.log` file for details."
             )
+            # 何故か{error_log_path}をraiseすると文字コードエラーが起きるので上のように書いている
     else:
         logger.info(
             "Training set and validation set generation from texts is complete!"

--- a/server_editor.py
+++ b/server_editor.py
@@ -19,7 +19,6 @@ from pathlib import Path
 import yaml
 
 import numpy as np
-import pyopenjtalk
 import requests
 import torch
 import uvicorn

--- a/text/japanese.py
+++ b/text/japanese.py
@@ -4,7 +4,9 @@ import re
 import unicodedata
 from pathlib import Path
 
-import pyopenjtalk
+from . import pyopenjtalk_worker as pyopenjtalk
+
+pyopenjtalk.initialize()
 from num2words import num2words
 from transformers import AutoTokenizer
 

--- a/text/pyopenjtalk_worker/__init__.py
+++ b/text/pyopenjtalk_worker/__init__.py
@@ -64,7 +64,7 @@ def initialize(port: int = WOKER_PORT):
     try:
         client = WorkerClient(port)
     except (socket.timeout, socket.error):
-        logger.debug("try starting worker server")
+        logger.debug("try starting pyopenjtalk worker server")
         import os
         import subprocess
 

--- a/text/pyopenjtalk_worker/__init__.py
+++ b/text/pyopenjtalk_worker/__init__.py
@@ -54,6 +54,7 @@ def initialize(port: int = WOKER_PORT):
     import socket
     import sys
     import atexit
+    import signal
 
     logger.debug("initialize")
     global WORKER_CLIENT
@@ -99,6 +100,15 @@ def initialize(port: int = WOKER_PORT):
 
     WORKER_CLIENT = client
     atexit.register(terminate)
+
+    # when the process is killed
+    def signal_handler(signum, frame):
+        with open("signal_handler.txt", mode="w") as f:
+
+            pass
+        terminate()
+
+    signal.signal(signal.SIGTERM, signal_handler)
 
 
 # top-level declaration

--- a/text/pyopenjtalk_worker/__init__.py
+++ b/text/pyopenjtalk_worker/__init__.py
@@ -74,8 +74,11 @@ def initialize(port: int = WOKER_PORT):
         args = [sys.executable, "-m", worker_pkg_path, "--port", str(port)]
         # new session, new process group
         if sys.platform.startswith("win"):
-            cf = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore
-            subprocess.Popen(args, creationflags=cf)
+            cf = subprocess.CREATE_NEW_CONSOLE | subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore
+            si = subprocess.STARTUPINFO()  # type: ignore
+            si.dwFlags |= subprocess.STARTF_USESHOWWINDOW  # type: ignore
+            si.wShowWindow = subprocess.SW_HIDE  # type: ignore
+            subprocess.Popen(args, creationflags=cf, startupinfo=si)
         else:
             # align with Windows behavior
             # start_new_session is same as specifying setsid in preexec_fn
@@ -107,7 +110,7 @@ def terminate():
 
     # repare for unexpected errors
     try:
-        if WORKER_CLIENT.status().get("client-count") == 1:
+        if WORKER_CLIENT.status() == 1:
             WORKER_CLIENT.quit_server()
     except Exception as e:
         logger.error(e)

--- a/text/pyopenjtalk_worker/__init__.py
+++ b/text/pyopenjtalk_worker/__init__.py
@@ -103,9 +103,6 @@ def initialize(port: int = WOKER_PORT):
 
     # when the process is killed
     def signal_handler(signum, frame):
-        with open("signal_handler.txt", mode="w") as f:
-
-            pass
         terminate()
 
     signal.signal(signal.SIGTERM, signal_handler)

--- a/text/pyopenjtalk_worker/__init__.py
+++ b/text/pyopenjtalk_worker/__init__.py
@@ -1,0 +1,100 @@
+"""
+Run the pyopenjtalk worker in a separate process
+to avoid user dictionary access error
+"""
+
+from typing import Optional, Any
+
+from .worker_common import WOKER_PORT
+from .worker_client import WorkerClient
+
+from common.log import logger
+
+WORKER_CLIENT: Optional[WorkerClient] = None
+
+# pyopenjtalk interface
+
+# g2p: not used
+
+
+def run_frontend(text: str) -> list[dict[str, Any]]:
+    assert WORKER_CLIENT
+    ret = WORKER_CLIENT.dispatch_pyopenjtalk("run_frontend", text)
+    assert isinstance(ret, list)
+    return ret
+
+
+def make_label(njd_features) -> list[str]:
+    assert WORKER_CLIENT
+    ret = WORKER_CLIENT.dispatch_pyopenjtalk("make_label", njd_features)
+    assert isinstance(ret, list)
+    return ret
+
+
+def mecab_dict_index(path: str, out_path: str, dn_mecab: Optional[str] = None):
+    assert WORKER_CLIENT
+    WORKER_CLIENT.dispatch_pyopenjtalk("mecab_dict_index", path, out_path, dn_mecab)
+
+
+def update_global_jtalk_with_user_dict(path: str):
+    assert WORKER_CLIENT
+    WORKER_CLIENT.dispatch_pyopenjtalk("update_global_jtalk_with_user_dict", path)
+
+
+def unset_user_dict():
+    assert WORKER_CLIENT
+    WORKER_CLIENT.dispatch_pyopenjtalk("unset_user_dict")
+
+
+# initialize module when imported
+
+
+def initialize(port: int = WOKER_PORT):
+    import time
+    import socket
+    import sys
+    import atexit
+
+    global WORKER_CLIENT
+    logger.debug("initialize")
+    if WORKER_CLIENT:
+        return
+
+    client = None
+    try:
+        client = WorkerClient(port)
+    except (socket.timeout, socket.error):
+        logger.debug("try starting worker server")
+        import os
+        import subprocess
+
+        worker_pkg_path = os.path.relpath(
+            os.path.dirname(__file__), os.getcwd()
+        ).replace(os.sep, ".")
+        subprocess.Popen([sys.executable, "-m", worker_pkg_path, "--port", str(port)])
+        # wait until server listening
+        count = 0
+        while True:
+            try:
+                client = WorkerClient(port)
+                break
+            except socket.error:
+                time.sleep(1)
+                count += 1
+                # 10: max number of retries
+                if count == 10:
+                    raise TimeoutError("サーバーに接続できませんでした")
+
+    WORKER_CLIENT = client
+
+    def terminate():
+        global WORKER_CLIENT
+        if not WORKER_CLIENT:
+            return
+
+        if WORKER_CLIENT.status().get("client-count") == 1:
+            WORKER_CLIENT.quit_server()
+        WORKER_CLIENT.close()
+        WORKER_CLIENT = None
+
+    atexit.register(terminate)

--- a/text/pyopenjtalk_worker/__main__.py
+++ b/text/pyopenjtalk_worker/__main__.py
@@ -1,0 +1,16 @@
+import argparse
+
+from .worker_server import WorkerServer
+from .worker_common import WOKER_PORT
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=WOKER_PORT)
+    args = parser.parse_args()
+    server = WorkerServer()
+    server.start_server(port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/text/pyopenjtalk_worker/worker_client.py
+++ b/text/pyopenjtalk_worker/worker_client.py
@@ -1,0 +1,40 @@
+from typing import Any
+import socket
+
+from .worker_common import RequestType, receive_data, send_data
+
+
+class WorkerClient:
+    def __init__(self, port: int) -> None:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # 5: timeout
+        sock.settimeout(5)
+        sock.connect((socket.gethostname(), port))
+        self.sock = sock
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
+        self.sock.close()
+
+    def dispatch_pyopenjtalk(self, func: str, *args, **kwargs):
+        data = {
+            "request-type": RequestType.PYOPENJTALK,
+            "func": func,
+            "args": args,
+            "kwargs": kwargs,
+        }
+        send_data(self.sock, data)
+        return receive_data(self.sock).get("return")
+
+    def status(self):
+        send_data(self.sock, {"request-type": RequestType.STATUS})
+        return receive_data(self.sock)
+
+    def quit_server(self):
+        send_data(self.sock, {"request-type": RequestType.QUIT_SERVER})
+        receive_data(self.sock)

--- a/text/pyopenjtalk_worker/worker_client.py
+++ b/text/pyopenjtalk_worker/worker_client.py
@@ -3,6 +3,8 @@ import socket
 
 from .worker_common import RequestType, receive_data, send_data
 
+from common.log import logger
+
 
 class WorkerClient:
     def __init__(self, port: int) -> None:
@@ -28,8 +30,12 @@ class WorkerClient:
             "args": args,
             "kwargs": kwargs,
         }
+        logger.trace(f"client sends request: {data}")
         send_data(self.sock, data)
-        return receive_data(self.sock).get("return")
+        logger.trace("client sent request successfully")
+        response = receive_data(self.sock)
+        logger.trace(f"client received response: {response}")
+        return response.get("return")
 
     def status(self):
         send_data(self.sock, {"request-type": RequestType.STATUS})

--- a/text/pyopenjtalk_worker/worker_client.py
+++ b/text/pyopenjtalk_worker/worker_client.py
@@ -38,9 +38,18 @@ class WorkerClient:
         return response.get("return")
 
     def status(self):
-        send_data(self.sock, {"request-type": RequestType.STATUS})
-        return receive_data(self.sock)
+        data = {"request-type": RequestType.STATUS}
+        logger.trace(f"client sends request: {data}")
+        send_data(self.sock, data)
+        logger.trace("client sent request successfully")
+        response = receive_data(self.sock)
+        logger.trace(f"client received response: {response}")
+        return response.get("client-count")
 
     def quit_server(self):
-        send_data(self.sock, {"request-type": RequestType.QUIT_SERVER})
-        receive_data(self.sock)
+        data = {"request-type": RequestType.QUIT_SERVER}
+        logger.trace(f"client sends request: {data}")
+        send_data(self.sock, data)
+        logger.trace("client sent request successfully")
+        response = receive_data(self.sock)
+        logger.trace(f"client received response: {response}")

--- a/text/pyopenjtalk_worker/worker_common.py
+++ b/text/pyopenjtalk_worker/worker_common.py
@@ -1,0 +1,44 @@
+from typing import Any, Optional, Final
+from enum import IntEnum, auto
+import socket
+import json
+
+WOKER_PORT: Final[int] = 7861
+HEADER_SIZE: Final[int] = 4
+
+
+class RequestType(IntEnum):
+    STATUS = auto()
+    QUIT_SERVER = auto()
+    PYOPENJTALK = auto()
+
+
+class ConnectionClosedException(Exception):
+    pass
+
+
+# socket communication
+
+
+def send_data(sock: socket.socket, data: dict[str, Any]):
+    json_data = json.dumps(data).encode()
+    header = len(json_data).to_bytes(HEADER_SIZE, byteorder="big")
+    sock.sendall(header + json_data)
+
+
+def _receive_until(sock: socket.socket, size: int):
+    data = b""
+    while len(data) < size:
+        part = sock.recv(size - len(data))
+        if part == b"":
+            raise ConnectionClosedException("接続が閉じられました")
+        data += part
+
+    return data
+
+
+def receive_data(sock: socket.socket) -> dict[str, Any]:
+    header = _receive_until(sock, HEADER_SIZE)
+    data_length = int.from_bytes(header, byteorder="big")
+    body = _receive_until(sock, data_length)
+    return json.loads(body.decode())

--- a/text/pyopenjtalk_worker/worker_server.py
+++ b/text/pyopenjtalk_worker/worker_server.py
@@ -1,0 +1,103 @@
+import pyopenjtalk
+import socket
+import select
+
+
+from .worker_common import (
+    ConnectionClosedException,
+    RequestType,
+    receive_data,
+    send_data,
+)
+
+from common.log import logger
+
+# To make it as fast as possible
+# Probably faster than calling getattr every time
+_PYOPENJTALK_FUNC_DICT = {
+    "run_frontend": pyopenjtalk.run_frontend,
+    "make_label": pyopenjtalk.make_label,
+    "mecab_dict_index": pyopenjtalk.mecab_dict_index,
+    "update_global_jtalk_with_user_dict": pyopenjtalk.update_global_jtalk_with_user_dict,
+    "unset_user_dict": pyopenjtalk.unset_user_dict,
+}
+
+
+class WorkerServer:
+    def __init__(self) -> None:
+        self.client_count: int = 0
+        self.quit: bool = False
+
+    def handle_request(self, request):
+        request_type = None
+        try:
+            request_type = RequestType(request.get("request-type"))
+        except Exception:
+            return {
+                "success": False,
+                "reason": "request-type is invalid",
+            }
+
+        if request_type:
+            if request_type == RequestType.STATUS:
+                response = {
+                    "success": True,
+                    "client-count": self.client_count,
+                }
+            elif request_type == RequestType.QUIT_SERVER:
+                self.quit = True
+                response = {"success": True}
+            elif request_type == RequestType.PYOPENJTALK:
+                func_name = request.get("func")
+                assert isinstance(func_name, str)
+                func = _PYOPENJTALK_FUNC_DICT[func_name]
+                args = request.get("args")
+                kwargs = request.get("kwargs")
+                assert isinstance(args, list)
+                assert isinstance(kwargs, dict)
+                ret = func(*args, **kwargs)
+                response = {"success": True, "return": ret}
+            else:
+                # NOT REACHED
+                response = request
+
+        return response
+
+    def start_server(self, port: int):
+        logger.info("start pyopenjtalk worker server")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+            server_socket.bind((socket.gethostname(), port))
+            server_socket.listen()
+            sockets = [server_socket]
+            while True:
+                ready_sockets, _, _ = select.select(sockets, [], [], 0.1)
+                for sock in ready_sockets:
+                    if sock is server_socket:
+                        logger.info("new client connected")
+                        client_socket, _ = server_socket.accept()
+                        sockets.append(client_socket)
+                        self.client_count += 1
+                    else:
+                        # client
+                        try:
+                            request = receive_data(sock)
+                        except ConnectionClosedException as e:
+                            sock.close()
+                            sockets.remove(sock)
+                            self.client_count -= 1
+                            logger.info("close connection")
+                            continue
+
+                        logger.debug(f"receive request: {request}")
+
+                        response = self.handle_request(request)
+                        logger.debug(f"send response: {response}")
+                        try:
+                            send_data(sock, response)
+                        except Exception:
+                            logger.warning(
+                                "an exception occurred during sending responce"
+                            )
+                        if self.quit:
+                            logger.info("quit pyopenjtalk worker server")
+                            return

--- a/text/pyopenjtalk_worker/worker_server.py
+++ b/text/pyopenjtalk_worker/worker_server.py
@@ -2,7 +2,6 @@ import pyopenjtalk
 import socket
 import select
 
-
 from .worker_common import (
     ConnectionClosedException,
     RequestType,
@@ -88,12 +87,13 @@ class WorkerServer:
                             logger.info("close connection")
                             continue
 
-                        logger.debug(f"receive request: {request}")
+                        logger.trace(f"server received request: {request}")
 
                         response = self.handle_request(request)
-                        logger.debug(f"send response: {response}")
+                        logger.trace(f"server sends response: {response}")
                         try:
                             send_data(sock, response)
+                            logger.trace("server sent response successfully")
                         except Exception:
                             logger.warning(
                                 "an exception occurred during sending responce"

--- a/text/pyopenjtalk_worker/worker_server.py
+++ b/text/pyopenjtalk_worker/worker_server.py
@@ -86,6 +86,12 @@ class WorkerServer:
                             self.client_count -= 1
                             logger.info("close connection")
                             continue
+                        except Exception as e:
+                            sock.close()
+                            sockets.remove(sock)
+                            self.client_count -= 1
+                            logger.error(e)
+                            continue
 
                         logger.trace(f"server received request: {request}")
 

--- a/text/user_dict/__init__.py
+++ b/text/user_dict/__init__.py
@@ -12,7 +12,9 @@ from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 
 import numpy as np
-import pyopenjtalk
+from .. import pyopenjtalk_worker as pyopenjtalk
+
+pyopenjtalk.initialize()
 from fastapi import HTTPException
 
 from .word_model import UserDictWord, WordTypes

--- a/transcribe.py
+++ b/transcribe.py
@@ -61,13 +61,9 @@ if __name__ == "__main__":
         logger.warning(f"Failed to load model, so use `auto` compute_type: {e}")
         model = WhisperModel(args.model, device=device)
 
-    # wav_files = [
-    #     os.path.join(input_dir, f) for f in os.listdir(input_dir) if f.endswith(".wav")
-    # ]
     wav_files = [f for f in input_dir.rglob("*.wav") if f.is_file()]
     if output_file.exists():
         logger.warning(f"{output_file} exists, backing up to {output_file}.bak")
-        # if os.path.exists(output_file + ".bak"):
         backup_path = output_file.with_name(output_file.name + ".bak")
         if backup_path.exists():
             logger.warning(f"{output_file}.bak exists, deleting...")


### PR DESCRIPTION
## 概要

#71 の対策として、pyopenjtalk別プロセス化とプロセス間通信を導入します。

## 仕様

### コード面
pyopenjtalk_workerというパッケージにまとめました。
従来のpyopenjtalk使用箇所はtextパッケージの中のモジュールのみだったので
この中に配置しました。

`import pyopenjtalk`
を
`from （相対的な位置関係） import pyopenjtalk_worker as pyopenjtalk`
に置き換えることでコード変更を最小限にとどめます。
また、importした後に初期化処理`initialize`を呼ぶようにします。
後述のサーバー起動を-mオプションによる__main__.pyを実行することにより
実現する関係上、必要です。
（呼ばずに振る舞いを切り替えられれば良かったのですが
どちらの場合も__init__.pyが呼ばれ、
importと-mオプションの分岐方法がわかりませんでした）

### プロセス間通信

TCPソケット通信により、行います。
クライアント: importしたプロセス
サーバー: 初期化処理によって起動したプロセス
importした後の初期化処理は以下の流れです。

1. まだサーバーが起動していなければ起動します。
2. その後、クライアントとして接続します。

処理速度やソケットの枯渇を考慮して、接続を保持し続けます。
終了時には接続が切断されるようにします。
また、自プロセスがサーバーに接続している最後のプロセスの場合、
サーバーに停止要求を送り、サーバーを終了します。
（必ずしもサーバーを起動したプロセスが終了させるとは限らない）

## 主な確認内容

1. server_editor.pyを起動

2. webui_train.pyを起動

4. esd.list にうまく読めない単語を含むようなデータを準備する
webuiでStep 3: 書き起こしファイルの前処理を行いesd.list.cleanedの音素を記録しておく
Ex. GNU
![image](https://github.com/litagin02/Style-Bert-VITS2/assets/60283342/f3fae8f8-ea78-4e77-9757-c60fd577288d)

5. エディターでユーザー辞書登録する
確認: エラーが出ずに終了すること
Ex. 読み: グヌウで登録
![image](https://github.com/litagin02/Style-Bert-VITS2/assets/60283342/bc055fc5-e841-4b2e-85e6-4860031996fc)
![image](https://github.com/litagin02/Style-Bert-VITS2/assets/60283342/892d5a66-efe7-47e2-9655-3ae8cc1e78bb)

6. webuiで再度、Step 3: 書き起こしファイルの前処理を行う
確認: エラーが出ずに終了すること

7. esd.list.cleaned を確認
確認: 音素がユーザー辞書登録した読みに対応するものになっていること
![image](https://github.com/litagin02/Style-Bert-VITS2/assets/60283342/fe4e3f29-9c84-40cb-ba42-5a18646fd91c)

8. エディターを終了する

9. webuiを終了する
確認: サーバープロセスが残っていないこと
Windows: タスクマネージャーでpythonがないこと
Linux: ps -aux | grep python でないこと

その他、server_fastapi.pyの方も確認しました。
* 辞書登録前後で、辞書に従って合成音声の読み方が変化すること

## 検討事項
* ポート番号を仮に7861に設定
値の妥当性やYAMLファイルによる設定変更機能の必要性
