### PR TITLE
openjtalkプロセス間通信のタイムアウト延長

### DIFF
--- a/text/pyopenjtalk_worker/worker_client.py
+++ b/text/pyopenjtalk_worker/worker_client.py
@@ -9,8 +9,8 @@ from common.log import logger
 class WorkerClient:
     def __init__(self, port: int) -> None:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # 5: timeout
-        sock.settimeout(5)
+        # 60: timeout
+        sock.settimeout(60)
         sock.connect((socket.gethostname(), port))
         self.sock = sock
 


### PR DESCRIPTION
## 概要

ユーザー辞書ファイルが大きい場合、server_editor.pyなどを実行すると、タイムアウトエラーになってしまうとの報告ありました。
5秒は短すぎたため、60秒に延長いたします。

## 確認内容

1. サイズが大きいユーザー辞書ファイル（CSV）を準備する
Ex. tdmelodic_openjtalk.csv
https://github.com/sarulab-speech/tdmelodic_openjtalk/tree/main


1. dict_dataにあるdefault.csvをバックアップし、準備したファイルに差し替える

1. server_editor.pyを実行する
確認: 正常に起動し、http://localhost:8000/にアクセスできること
