### PR TITLE
/voice を get から post に変更

### DIFF
--- a/server_fastapi.py
+++ b/server_fastapi.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         )
     app.logger = logger
 
-    @app.get("/voice", response_class=AudioResponse)
+    @app.post("/voice", response_class=AudioResponse)
     async def voice(
         request: Request,
         text: str = Query(..., min_length=1, max_length=limit, description=f"セリフ"),


### PR DESCRIPTION
GETリクエストだとURIエンコード込みで2000文字が限界なため、POSTリクエストに変更して一度に読み込める文字数を増やす。devで変更されているのを確認したが、できるだけ早めに変更したほうがいい。POSTリクエストだけでもマイナーバージョンを作ったほうがいい。他のリクエストも含めると日本語の文字で400文字ぐらいが限界で、APIを扱う上でとても厳しい制限だと思う。