### PR TITLE
faster_whisperのマルチGPU対応

### DIFF
--- a/gradio_tabs/dataset.py
+++ b/gradio_tabs/dataset.py
@@ -41,62 +41,32 @@ def do_slice(
 
 def do_transcribe(
     model_name,
-    whisper_model,
+    model,
     compute_type,
     language,
     initial_prompt,
     device,
-    device_indexs,
+    device_indexes,
     use_hf_whisper,
     batch_size,
     num_beams,
+    no_repeat_ngram_size: int = 10,
 ):
     if model_name == "":
         return "Error: モデル名を入力してください。"
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--model_name", type=str, required=True)
-    parser.add_argument(
-        "--initial_prompt",
-        type=str,
-        default="こんにちは。元気、ですかー？ふふっ、私は……ちゃんと元気だよ！",
-    )
-    parser.add_argument(
-        "--language", type=str, default="ja", choices=["ja", "en", "zh"]
-    )
-    parser.add_argument("--model", type=str, default="large-v3")
-    parser.add_argument("--device", type=str, default="cuda")
-    # GPUインデックス追加
-    parser.add_argument("--device_indexs", type=str, default="0")
-    parser.add_argument("--compute_type", type=str, default="bfloat16")
-    parser.add_argument("--use_hf_whisper", action="store_true")
-    parser.add_argument("--batch_size", type=int, default=16)
-    parser.add_argument("--num_beams", type=int, default=1)
-    parser.add_argument("--no_repeat_ngram_size", type=int, default=10)
-    args = parser.parse_args(
-        [
-        "--model_name", model_name, 
-        "--model", whisper_model, 
-        "--compute_type", compute_type, 
-        "--language", language, 
-        "--initial_prompt", initial_prompt, 
-        "--device", device, 
-        "--device_indexs", device_indexs 
-        ]
-    )
-
-    success, message = transcribe.main(
-        args.model_name, 
-        args.model, 
-        args.compute_type, 
-        args.language, 
-        args.initial_prompt, 
-        args.device, 
-        args.device_indexs, 
-        args.use_hf_whisper, 
-        args.batch_size, 
-        args.num_beams, 
-        args.no_repeat_ngram_size, 
+    success, message = transcribe.run(
+        model_name, 
+        model, 
+        compute_type, 
+        language, 
+        initial_prompt, 
+        device, 
+        device_indexes, 
+        use_hf_whisper, 
+        batch_size, 
+        num_beams, 
+        no_repeat_ngram_size, 
     )
     if not success:
         return f"Error: {message}. エラーメッセージが空の場合、何も問題がない可能性があるので、書き起こしファイルをチェックして問題なければ無視してください。"
@@ -105,12 +75,12 @@ def do_transcribe(
 import torch
 
 # 使用可能なGPUのインデックスリスト取得
-def get_gpu_indexs():
-    gpu_indexs = []
+def get_gpu_indexes():
+    gpu_indexes = []
     if torch.cuda.is_available():
         for i in range(torch.cuda.device_count()):
-            gpu_indexs.append(str(i))
-    return ','.join(gpu_indexs)
+            gpu_indexes.append(str(i))
+    return ','.join(gpu_indexes)
     '''
     cmd = [
         "transcribe.py",
@@ -253,9 +223,9 @@ def create_dataset_app() -> gr.Blocks:
                     visible=False,
                 )
                 device = gr.Radio(["cuda", "cpu"], label="デバイス", value="cuda")
-                device_indexs = gr.Textbox(
+                device_indexes = gr.Textbox(
                     label="使用GPUインデックス",
-                    value=get_gpu_indexs(),
+                    value=get_gpu_indexes(),
                     info="使用するGPUインデックスをカンマ区切りで指定、例文（0,1,2）",
                 )
                 language = gr.Dropdown(["ja", "en", "zh"], value="ja", label="言語")
@@ -295,7 +265,7 @@ def create_dataset_app() -> gr.Blocks:
                 language,
                 initial_prompt,
                 device,
-                device_indexs,
+                device_indexes,
                 use_hf_whisper,
                 batch_size,
                 num_beams,
@@ -309,7 +279,7 @@ def create_dataset_app() -> gr.Blocks:
                 gr.update(visible=not x),
             ),
             inputs=[use_hf_whisper],
-            outputs=[batch_size, compute_type, device, device_indexs],
+            outputs=[batch_size, compute_type, device],
         )
 
     return app

--- a/gradio_tabs/dataset.py
+++ b/gradio_tabs/dataset.py
@@ -3,8 +3,6 @@ import gradio as gr
 from style_bert_vits2.logging import logger
 from style_bert_vits2.utils.subprocess import run_script_with_log
 
-import argparse
-import transcribe
 
 def do_slice(
     model_name: str,
@@ -46,7 +44,6 @@ def do_transcribe(
     language,
     initial_prompt,
     device,
-    device_indexs,
     use_hf_whisper,
     batch_size,
     num_beams,
@@ -54,64 +51,6 @@ def do_transcribe(
     if model_name == "":
         return "Error: モデル名を入力してください。"
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--model_name", type=str, required=True)
-    parser.add_argument(
-        "--initial_prompt",
-        type=str,
-        default="こんにちは。元気、ですかー？ふふっ、私は……ちゃんと元気だよ！",
-    )
-    parser.add_argument(
-        "--language", type=str, default="ja", choices=["ja", "en", "zh"]
-    )
-    parser.add_argument("--model", type=str, default="large-v3")
-    parser.add_argument("--device", type=str, default="cuda")
-    # GPUインデックス追加
-    parser.add_argument("--device_indexs", type=str, default="0")
-    parser.add_argument("--compute_type", type=str, default="bfloat16")
-    parser.add_argument("--use_hf_whisper", action="store_true")
-    parser.add_argument("--batch_size", type=int, default=16)
-    parser.add_argument("--num_beams", type=int, default=1)
-    parser.add_argument("--no_repeat_ngram_size", type=int, default=10)
-    args = parser.parse_args(
-        [
-        "--model_name", model_name, 
-        "--model", whisper_model, 
-        "--compute_type", compute_type, 
-        "--language", language, 
-        "--initial_prompt", initial_prompt, 
-        "--device", device, 
-        "--device_indexs", device_indexs 
-        ]
-    )
-
-    success, message = transcribe.main(
-        args.model_name, 
-        args.model, 
-        args.compute_type, 
-        args.language, 
-        args.initial_prompt, 
-        args.device, 
-        args.device_indexs, 
-        args.use_hf_whisper, 
-        args.batch_size, 
-        args.num_beams, 
-        args.no_repeat_ngram_size, 
-    )
-    if not success:
-        return f"Error: {message}. エラーメッセージが空の場合、何も問題がない可能性があるので、書き起こしファイルをチェックして問題なければ無視してください。"
-    return "音声の文字起こしが完了しました。"
-
-import torch
-
-# 使用可能なGPUのインデックスリスト取得
-def get_gpu_indexs():
-    gpu_indexs = []
-    if torch.cuda.is_available():
-        for i in range(torch.cuda.device_count()):
-            gpu_indexs.append(str(i))
-    return ','.join(gpu_indexs)
-    '''
     cmd = [
         "transcribe.py",
         "--model_name",
@@ -135,7 +74,7 @@ def get_gpu_indexs():
     success, message = run_script_with_log(cmd)
     if not success:
         return f"Error: {message}. エラーメッセージが空の場合、何も問題がない可能性があるので、書き起こしファイルをチェックして問題なければ無視してください。"
-    '''
+
 
 how_to_md = """
 Style-Bert-VITS2の学習用データセットを作成するためのツールです。以下の2つからなります。
@@ -253,11 +192,6 @@ def create_dataset_app() -> gr.Blocks:
                     visible=False,
                 )
                 device = gr.Radio(["cuda", "cpu"], label="デバイス", value="cuda")
-                device_indexs = gr.Textbox(
-                    label="使用GPUインデックス",
-                    value=get_gpu_indexs(),
-                    info="使用するGPUインデックスをカンマ区切りで指定、例文（0,1,2）",
-                )
                 language = gr.Dropdown(["ja", "en", "zh"], value="ja", label="言語")
                 initial_prompt = gr.Textbox(
                     label="初期プロンプト",
@@ -295,7 +229,6 @@ def create_dataset_app() -> gr.Blocks:
                 language,
                 initial_prompt,
                 device,
-                device_indexs,
                 use_hf_whisper,
                 batch_size,
                 num_beams,
@@ -309,7 +242,7 @@ def create_dataset_app() -> gr.Blocks:
                 gr.update(visible=not x),
             ),
             inputs=[use_hf_whisper],
-            outputs=[batch_size, compute_type, device, device_indexs],
+            outputs=[batch_size, compute_type, device],
         )
 
     return app

--- a/gradio_tabs/dataset.py
+++ b/gradio_tabs/dataset.py
@@ -3,6 +3,8 @@ import gradio as gr
 from style_bert_vits2.logging import logger
 from style_bert_vits2.utils.subprocess import run_script_with_log
 
+import argparse
+import transcribe
 
 def do_slice(
     model_name: str,
@@ -44,6 +46,7 @@ def do_transcribe(
     language,
     initial_prompt,
     device,
+    device_indexs,
     use_hf_whisper,
     batch_size,
     num_beams,
@@ -51,6 +54,64 @@ def do_transcribe(
     if model_name == "":
         return "Error: モデル名を入力してください。"
 
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_name", type=str, required=True)
+    parser.add_argument(
+        "--initial_prompt",
+        type=str,
+        default="こんにちは。元気、ですかー？ふふっ、私は……ちゃんと元気だよ！",
+    )
+    parser.add_argument(
+        "--language", type=str, default="ja", choices=["ja", "en", "zh"]
+    )
+    parser.add_argument("--model", type=str, default="large-v3")
+    parser.add_argument("--device", type=str, default="cuda")
+    # GPUインデックス追加
+    parser.add_argument("--device_indexs", type=str, default="0")
+    parser.add_argument("--compute_type", type=str, default="bfloat16")
+    parser.add_argument("--use_hf_whisper", action="store_true")
+    parser.add_argument("--batch_size", type=int, default=16)
+    parser.add_argument("--num_beams", type=int, default=1)
+    parser.add_argument("--no_repeat_ngram_size", type=int, default=10)
+    args = parser.parse_args(
+        [
+        "--model_name", model_name, 
+        "--model", whisper_model, 
+        "--compute_type", compute_type, 
+        "--language", language, 
+        "--initial_prompt", initial_prompt, 
+        "--device", device, 
+        "--device_indexs", device_indexs 
+        ]
+    )
+
+    success, message = transcribe.main(
+        args.model_name, 
+        args.model, 
+        args.compute_type, 
+        args.language, 
+        args.initial_prompt, 
+        args.device, 
+        args.device_indexs, 
+        args.use_hf_whisper, 
+        args.batch_size, 
+        args.num_beams, 
+        args.no_repeat_ngram_size, 
+    )
+    if not success:
+        return f"Error: {message}. エラーメッセージが空の場合、何も問題がない可能性があるので、書き起こしファイルをチェックして問題なければ無視してください。"
+    return "音声の文字起こしが完了しました。"
+
+import torch
+
+# 使用可能なGPUのインデックスリスト取得
+def get_gpu_indexs():
+    gpu_indexs = []
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            gpu_indexs.append(str(i))
+    return ','.join(gpu_indexs)
+    '''
     cmd = [
         "transcribe.py",
         "--model_name",
@@ -74,7 +135,7 @@ def do_transcribe(
     success, message = run_script_with_log(cmd)
     if not success:
         return f"Error: {message}. エラーメッセージが空の場合、何も問題がない可能性があるので、書き起こしファイルをチェックして問題なければ無視してください。"
-
+    '''
 
 how_to_md = """
 Style-Bert-VITS2の学習用データセットを作成するためのツールです。以下の2つからなります。
@@ -192,6 +253,11 @@ def create_dataset_app() -> gr.Blocks:
                     visible=False,
                 )
                 device = gr.Radio(["cuda", "cpu"], label="デバイス", value="cuda")
+                device_indexs = gr.Textbox(
+                    label="使用GPUインデックス",
+                    value=get_gpu_indexs(),
+                    info="使用するGPUインデックスをカンマ区切りで指定、例文（0,1,2）",
+                )
                 language = gr.Dropdown(["ja", "en", "zh"], value="ja", label="言語")
                 initial_prompt = gr.Textbox(
                     label="初期プロンプト",
@@ -229,6 +295,7 @@ def create_dataset_app() -> gr.Blocks:
                 language,
                 initial_prompt,
                 device,
+                device_indexs,
                 use_hf_whisper,
                 batch_size,
                 num_beams,
@@ -242,7 +309,7 @@ def create_dataset_app() -> gr.Blocks:
                 gr.update(visible=not x),
             ),
             inputs=[use_hf_whisper],
-            outputs=[batch_size, compute_type, device],
+            outputs=[batch_size, compute_type, device, device_indexs],
         )
 
     return app

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,3 @@ tensorboard
 torch>=2.1
 transformers
 umap-learn
-portalocker

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ tensorboard
 torch>=2.1
 transformers
 umap-learn
+portalocker

--- a/transcribe.py
+++ b/transcribe.py
@@ -151,14 +151,14 @@ def transcribe_files_with_hf_whisper(
 
     return results
 
-def main(
+def run(
     model_name:str, 
     model:str="large-v3", 
     compute_type:str="bfloat16", 
     language:str="ja", 
     initial_prompt:str="こんにちは。元気、ですかー？ふふっ、私は……ちゃんと元気だよ！", 
     device:str="cuda", 
-    device_indexs:str="0", 
+    device_indexes:str="0", 
     use_hf_whisper=True, 
     batch_size:int=16, 
     num_beams:int=1, 
@@ -178,7 +178,7 @@ def main(
     language: str = language
     device: str = device
     # GPUインデックスリスト
-    device_indexs = [int(x) for x in device_indexs.split(',')]
+    device_indexes = [int(x) for x in device_indexes.split(',')]
     compute_type: str = compute_type
     batch_size: int = batch_size
     num_beams: int = num_beams
@@ -216,7 +216,7 @@ def main(
         models = {}
 
         # 使用するGPUの数だけモデルを作成する。
-        for device_index in device_indexs:
+        for device_index in device_indexes:
             try:
                 model_object = WhisperModel(model, device=device, device_index=device_index, compute_type=compute_type)
             except ValueError as e:
@@ -254,7 +254,7 @@ def main(
             thread.join()
 
         # モデルの解放
-        for device_index in device_indexs:
+        for device_index in device_indexes:
             models[device_index]=None
 
         '''
@@ -310,7 +310,7 @@ if __name__ == "__main__":
     parser.add_argument("--model", type=str, default="large-v3")
     parser.add_argument("--device", type=str, default="cuda")
     # GPUインデックス追加
-    parser.add_argument("--device_indexs", type=str, default="0")
+    parser.add_argument("--device_indexes", type=str, default="0")
     parser.add_argument("--compute_type", type=str, default="bfloat16")
     parser.add_argument("--use_hf_whisper", action="store_true")
     parser.add_argument("--batch_size", type=int, default=16)
@@ -318,14 +318,14 @@ if __name__ == "__main__":
     parser.add_argument("--no_repeat_ngram_size", type=int, default=10)
     args = parser.parse_args()
 
-    main(
+    run(
         args.model_name, 
         args.model, 
         args.compute_type, 
         args.language, 
         args.initial_prompt, 
         args.device, 
-        args.device_indexs, 
+        args.device_indexes, 
         args.use_hf_whisper, 
         args.batch_size, 
         args.num_beams, 

--- a/transcribe.py
+++ b/transcribe.py
@@ -12,54 +12,6 @@ from style_bert_vits2.constants import Languages
 from style_bert_vits2.logging import logger
 from style_bert_vits2.utils.stdout_wrapper import SAFE_STDOUT
 
-from threading import Thread
-import queue
-import time
-# 使用可能なGPUインデックスを入れるキュー
-device_queue = queue.Queue()
-
-def transcribe_thread(
-    model, 
-    device_index, 
-    wav_file, 
-    output_file, 
-    model_name, 
-    language_id, 
-    initial_prompt, 
-    language, 
-    num_beams, 
-    no_repeat_ngram_size
-):
-
-    text = transcribe_with_faster_whisper(
-        model=model,
-        audio_file=wav_file,
-        initial_prompt=initial_prompt,
-        language=language,
-        num_beams=num_beams,
-        no_repeat_ngram_size=no_repeat_ngram_size,
-    )
-
-    with open(output_file, "a", encoding="utf-8") as f:
-        if lock_file(f):
-            f.write(f"{wav_file.name}|{model_name}|{language_id}|{text}\n")
-            unlock_file(f)
-
-    device_queue.put(device_index)
-
-import portalocker
-
-def lock_file(file_obj):
-    try:
-        # ファイルに排他ロックを設定する
-        portalocker.lock(file_obj, portalocker.LOCK_EX)
-        return True
-    except portalocker.LockException:
-        return False
-
-def unlock_file(file_obj):
-    # ファイルのロックを解除する
-    portalocker.unlock(file_obj)
 
 # faster-whisperは並列処理しても速度が向上しないので、単一モデルでループ処理する
 def transcribe_with_faster_whisper(
@@ -151,38 +103,43 @@ def transcribe_files_with_hf_whisper(
 
     return results
 
-def main(
-    model_name:str, 
-    model:str="large-v3", 
-    compute_type:str="bfloat16", 
-    language:str="ja", 
-    initial_prompt:str="こんにちは。元気、ですかー？ふふっ、私は……ちゃんと元気だよ！", 
-    device:str="cuda", 
-    device_indexs:str="0", 
-    use_hf_whisper=True, 
-    batch_size:int=16, 
-    num_beams:int=1, 
-    no_repeat_ngram_size:int=10,
-):
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_name", type=str, required=True)
+    parser.add_argument(
+        "--initial_prompt",
+        type=str,
+        default="こんにちは。元気、ですかー？ふふっ、私は……ちゃんと元気だよ！",
+    )
+    parser.add_argument(
+        "--language", type=str, default="ja", choices=["ja", "en", "zh"]
+    )
+    parser.add_argument("--model", type=str, default="large-v3")
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--compute_type", type=str, default="bfloat16")
+    parser.add_argument("--use_hf_whisper", action="store_true")
+    parser.add_argument("--batch_size", type=int, default=16)
+    parser.add_argument("--num_beams", type=int, default=1)
+    parser.add_argument("--no_repeat_ngram_size", type=int, default=10)
+    args = parser.parse_args()
 
     with open(os.path.join("configs", "paths.yml"), "r", encoding="utf-8") as f:
         path_config: dict[str, str] = yaml.safe_load(f.read())
         dataset_root = Path(path_config["dataset_root"])
 
-    model_name = str(model_name)
+    model_name = str(args.model_name)
 
     input_dir = dataset_root / model_name / "raw"
     output_file = dataset_root / model_name / "esd.list"
-    initial_prompt: str = initial_prompt
+    initial_prompt: str = args.initial_prompt
     initial_prompt = initial_prompt.strip('"')
-    language: str = language
-    device: str = device
-    # GPUインデックスリスト
-    device_indexs = [int(x) for x in device_indexs.split(',')]
-    compute_type: str = compute_type
-    batch_size: int = batch_size
-    num_beams: int = num_beams
-    no_repeat_ngram_size: int = no_repeat_ngram_size
+    language: str = args.language
+    device: str = args.device
+    compute_type: str = args.compute_type
+    batch_size: int = args.batch_size
+    num_beams: int = args.num_beams
+    no_repeat_ngram_size: int = args.no_repeat_ngram_size
 
     output_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -206,58 +163,12 @@ def main(
     else:
         raise ValueError(f"{language} is not supported.")
 
-    if not use_hf_whisper:
+    if not args.use_hf_whisper:
         from faster_whisper import WhisperModel
 
         logger.info(
-            f"Loading faster-whisper model ({model}) with compute_type={compute_type}"
+            f"Loading faster-whisper model ({args.model}) with compute_type={compute_type}"
         )
-
-        models = {}
-
-        # 使用するGPUの数だけモデルを作成する。
-        for device_index in device_indexs:
-            try:
-                model_object = WhisperModel(model, device=device, device_index=device_index, compute_type=compute_type)
-            except ValueError as e:
-                logger.warning(f"Failed to load model, so use `auto` compute_type: {e}")
-                model_object = WhisperModel(model, device=device, device_index=device_index)
-            models[device_index]=model_object
-            # 使用可能なモデルのキューを入れる
-            device_queue.put(device_index)
-
-        # マルチスレッド開始
-        threads = []
-        for wav_file in tqdm(wav_files):
-            while True:
-                # 使用可能なモデルが無ければループする。
-                if not device_queue.empty():
-                    device_index = device_queue.get()
-                    thread = Thread(target=transcribe_thread, args=(
-                        models[device_index], 
-                        device_index, 
-                        wav_file, 
-                        output_file, 
-                        model_name, 
-                        language_id, 
-                        initial_prompt, 
-                        language, 
-                        num_beams, 
-                        no_repeat_ngram_size
-                    ))
-                    thread.start()
-                    threads.append(thread)
-                    break
-                time.sleep(0.01)
-
-        for thread in threads:
-            thread.join()
-
-        # モデルの解放
-        for device_index in device_indexs:
-            models[device_index]=None
-
-        '''
         try:
             model = WhisperModel(args.model, device=device, compute_type=compute_type)
         except ValueError as e:
@@ -274,9 +185,8 @@ def main(
             )
             with open(output_file, "a", encoding="utf-8") as f:
                 f.write(f"{wav_file.name}|{model_name}|{language_id}|{text}\n")
-        '''
     else:
-        model_id = f"openai/whisper-{model}"
+        model_id = f"openai/whisper-{args.model}"
         logger.info(f"Loading HF Whisper model ({model_id})")
         pbar = tqdm(total=len(wav_files), file=SAFE_STDOUT)
         results = transcribe_files_with_hf_whisper(
@@ -293,43 +203,5 @@ def main(
         with open(output_file, "w", encoding="utf-8") as f:
             for wav_file, text in zip(wav_files, results):
                 f.write(f"{wav_file.name}|{model_name}|{language_id}|{text}\n")
-
-    return True, ""
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--model_name", type=str, required=True)
-    parser.add_argument(
-        "--initial_prompt",
-        type=str,
-        default="こんにちは。元気、ですかー？ふふっ、私は……ちゃんと元気だよ！",
-    )
-    parser.add_argument(
-        "--language", type=str, default="ja", choices=["ja", "en", "zh"]
-    )
-    parser.add_argument("--model", type=str, default="large-v3")
-    parser.add_argument("--device", type=str, default="cuda")
-    # GPUインデックス追加
-    parser.add_argument("--device_indexs", type=str, default="0")
-    parser.add_argument("--compute_type", type=str, default="bfloat16")
-    parser.add_argument("--use_hf_whisper", action="store_true")
-    parser.add_argument("--batch_size", type=int, default=16)
-    parser.add_argument("--num_beams", type=int, default=1)
-    parser.add_argument("--no_repeat_ngram_size", type=int, default=10)
-    args = parser.parse_args()
-
-    main(
-        args.model_name, 
-        args.model, 
-        args.compute_type, 
-        args.language, 
-        args.initial_prompt, 
-        args.device, 
-        args.device_indexs, 
-        args.use_hf_whisper, 
-        args.batch_size, 
-        args.num_beams, 
-        args.no_repeat_ngram_size, 
-    )
 
     sys.exit(0)

--- a/transcribe.py
+++ b/transcribe.py
@@ -42,7 +42,7 @@ def transcribe_thread(
 
     with open(output_file, "a", encoding="utf-8") as f:
         if lock_file(f):
-            f.write(f"{wav_file.name}|{model_name}|{language_id}|{text}\n")
+            f.write(f"{wav_file}|{model_name}|{language_id}|{text}\n")
             unlock_file(f)
 
     device_queue.put(device_index)
@@ -292,7 +292,7 @@ def run(
         )
         with open(output_file, "w", encoding="utf-8") as f:
             for wav_file, text in zip(wav_files, results):
-                f.write(f"{wav_file.name}|{model_name}|{language_id}|{text}\n")
+                f.write(f"{wav_file}|{model_name}|{language_id}|{text}\n")
 
     return True, ""
 


### PR DESCRIPTION
faster_whisperのマルチGPU対応、マルチスレッドを使用する。
Threadとsubprocessの相性が悪くエラーになってしまうので、run_script_with_log()の使用をやめて
transcribe.main()を新しく作成した。
使用するGPUインデックスのパラメーターのdevice_indexsを追加した。
マルチスレッドにした為、esd.listを出力する際に排他ロックを掛けるportalockerモジュールをインストールした。