### PR TITLE
マージ時にspk2idを設定する

### DIFF
--- a/gradio_tabs/merge.py
+++ b/gradio_tabs/merge.py
@@ -104,6 +104,8 @@ def merge_style_usual(
     new_config = config_a.copy()
     new_config["data"]["num_styles"] = len(new_style2id)
     new_config["data"]["style2id"] = new_style2id
+    if new_config["data"]["n_speakers"] == 1:
+        new_config["data"]["spk2id"] = { output_name : 0}
     new_config["model_name"] = output_name
     save_config(new_config, output_name)
 
@@ -159,6 +161,8 @@ def merge_style_add_diff(
     new_config = config_a.copy()
     new_config["data"]["num_styles"] = len(new_style2id)
     new_config["data"]["style2id"] = new_style2id
+    if new_config["data"]["n_speakers"] == 1:
+        new_config["data"]["spk2id"] = { output_name : 0}
     new_config["model_name"] = output_name
     save_config(new_config, output_name)
 
@@ -218,6 +222,8 @@ def merge_style_weighted_sum(
     new_config = config_a.copy()
     new_config["data"]["num_styles"] = len(new_style2id)
     new_config["data"]["style2id"] = new_style2id
+    if new_config["data"]["n_speakers"] == 1:
+        new_config["data"]["spk2id"] = { output_name : 0}
     new_config["model_name"] = output_name
     save_config(new_config, output_name)
 
@@ -267,6 +273,8 @@ def merge_style_add_null(
     new_config = config_a.copy()
     new_config["data"]["num_styles"] = len(new_style2id)
     new_config["data"]["style2id"] = new_style2id
+    if new_config["data"]["n_speakers"] == 1:
+        new_config["data"]["spk2id"] = { output_name : 0}
     new_config["model_name"] = output_name
     save_config(new_config, output_name)
 
@@ -361,6 +369,8 @@ def merge_models_usual(
     new_config["model_name"] = output_name
     new_config["data"]["num_styles"] = 1
     new_config["data"]["style2id"] = {DEFAULT_STYLE: 0}
+    if new_config["data"]["n_speakers"] == 1:
+        new_config["data"]["spk2id"] = { output_name : 0}
     save_config(new_config, output_name)
 
     neutral_vector_a = style_vectors_a[0]
@@ -443,6 +453,8 @@ def merge_models_add_diff(
     new_config["model_name"] = output_name
     new_config["data"]["num_styles"] = 1
     new_config["data"]["style2id"] = {DEFAULT_STYLE: 0}
+    if new_config["data"]["n_speakers"] == 1:
+        new_config["data"]["spk2id"] = { output_name : 0}
     with open(assets_root / output_name / "config.json", "w", encoding="utf-8") as f:
         json.dump(new_config, f, indent=2, ensure_ascii=False)
 
@@ -518,6 +530,8 @@ def merge_models_weighted_sum(
     new_config["model_name"] = output_name
     new_config["data"]["num_styles"] = 1
     new_config["data"]["style2id"] = {DEFAULT_STYLE: 0}
+    if new_config["data"]["n_speakers"] == 1:
+        new_config["data"]["spk2id"] = { output_name : 0}
     with open(assets_root / output_name / "config.json", "w", encoding="utf-8") as f:
         json.dump(new_config, f, indent=2, ensure_ascii=False)
 
@@ -594,6 +608,8 @@ def merge_models_add_null(
     new_config["model_name"] = output_name
     new_config["data"]["num_styles"] = 1
     new_config["data"]["style2id"] = {DEFAULT_STYLE: 0}
+    if new_config["data"]["n_speakers"] == 1:
+        new_config["data"]["spk2id"] = { output_name : 0}
     with open(assets_root / output_name / "config.json", "w", encoding="utf-8") as f:
         json.dump(new_config, f, indent=2, ensure_ascii=False)
 


### PR DESCRIPTION
マージ時にモデル名をspk2idに設定します．
/models/infoで情報を取得した際にマージ元との区別が容易になります．