### PR TITLE
Fix: Missing onnx dependency

### DIFF
--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -9,6 +9,7 @@ loguru
 nltk<=3.8.1
 num2words
 numpy<2
+onnx
 onnxruntime
 onnxruntime-gpu
 pyannote.audio>=3.1.0

--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -12,6 +12,7 @@ numpy<2
 onnx
 onnxruntime
 onnxruntime-gpu
+onnxsim
 pyannote.audio>=3.1.0
 pyloudnorm
 pyopenjtalk-dict

--- a/requirements-infer.txt
+++ b/requirements-infer.txt
@@ -15,7 +15,7 @@ onnx
 onnxruntime
 onnxruntime-directml; sys_platform == 'win32'
 onnxruntime-gpu; sys_platform != 'darwin'
-# onnxsim
+onnxsim
 # protobuf==4.25
 psutil
 # punctuators

--- a/requirements-infer.txt
+++ b/requirements-infer.txt
@@ -11,6 +11,7 @@ loguru
 nltk<=3.8.1
 num2words
 numpy<2
+onnx
 onnxruntime
 onnxruntime-directml; sys_platform == 'win32'
 onnxruntime-gpu; sys_platform != 'darwin'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ loguru
 nltk<=3.8.1
 num2words
 numpy<2
+onnx
 onnxruntime
 onnxruntime-directml; sys_platform == 'win32'
 onnxruntime-gpu; sys_platform != 'darwin'


### PR DESCRIPTION
数日前にマージしていただいたプルリクエストですが、確認したところ現在の requirements.txt では ONNX 変換スクリプトに必要な `onnx` モジュールがインストールされないことがわかりましたので、その修正です。
環境によっては `onnxruntime` と一緒にインストールされているかもしれませんが、念のため…。
なお、変換スクリプト以外では不要なため、pyproject.toml には含めていません。