### PR TITLE
まれに「サーバーに接続できませんでした」エラーが起こる問題修正

### DIFF
--- a/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/worker_server.py
+++ b/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/worker_server.py
@@ -71,6 +71,7 @@ class WorkerServer:
     def start_server(self, port: int, no_client_timeout: int = 30) -> None:
         logger.info("start pyopenjtalk worker server")
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) 
             server_socket.bind((socket.gethostname(), port))
             server_socket.listen()
             sockets = [server_socket]


### PR DESCRIPTION
## 問題

* 高負荷
* アプリを終了し、時間をおかずに再起動

などの状況でまれに、app.py の実行で`サーバーに接続できませんでした`エラーになってしまう。

![image](https://github.com/user-attachments/assets/cac760e4-9aeb-4552-9ce9-a85127da349f)

## 原因

SO_REUSEADDR オプションがないことにより、TIME_WAIT状態のポートが残っている状態で
サーバーを起動しようとしたため。

## 修正内容

サーバーのbind前にオプション設定を追加。

```
server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) 
```

## 調査方法

Ubuntu 22.04 `stress`パッケージで CPU負荷を高い状況に設定。
（CPU24コア中22コアに負荷）

```
stress -c 22
```

`python3 app.py` を繰り返し実行。

また別ターミナルにおいてソケットの状態を確認。

```
watch -n 1 'ss -tan | grep 7860'
```

## 修正前

報告のあったエラーになることを確認しました。
またエラー時にサーバープロセスで以下の例外が起きていることを確認しました。

```
An exception occurred:
Traceback (most recent call last):
  File "/home/user/voice/work/Style-Bert-VITS2/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/worker_server.py", line 76, in start_server
    server_socket.bind((socket.gethostname(), port))
OSError: [Errno 98] Address already in use
```

## 修正後

エラーにならないことを確認しました。

## そのほか

ご迷惑をおかけし、申し訳ございません。
実装時もUbuntuやWindowsにおいて挙動は確認しましたが、
負荷の高い環境での確認や連続的な実行の可能性を考慮したソケットプログラミングへの理解が足りていなかったのは、私の不徳の致すところです。