### PR TITLE
fix: improve pyopenjtalk compatibility for newer versions and localhost binding

### DIFF
--- a/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/__init__.py
+++ b/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/__init__.py
@@ -68,7 +68,8 @@ def unset_user_dict() -> None:
         # without worker
         import pyopenjtalk
 
-        pyopenjtalk.unset_user_dict()
+        if hasattr(pyopenjtalk, 'unset_user_dict'):
+            pyopenjtalk.unset_user_dict()
 
 
 # initialize module when imported

--- a/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/worker_client.py
+++ b/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/worker_client.py
@@ -16,7 +16,7 @@ class WorkerClient:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         # timeout: 60 seconds
         sock.settimeout(60)
-        sock.connect((socket.gethostname(), port))
+        sock.connect(("localhost", port))
         self.sock = sock
 
     def __enter__(self) -> "WorkerClient":

--- a/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/worker_server.py
+++ b/style_bert_vits2/nlp/japanese/pyopenjtalk_worker/worker_server.py
@@ -21,8 +21,9 @@ PYOPENJTALK_FUNC_DICT = {
     "make_label": pyopenjtalk.make_label,
     "mecab_dict_index": pyopenjtalk.mecab_dict_index,
     "update_global_jtalk_with_user_dict": pyopenjtalk.update_global_jtalk_with_user_dict,
-    "unset_user_dict": pyopenjtalk.unset_user_dict,
 }
+if hasattr(pyopenjtalk, 'unset_user_dict'):
+    PYOPENJTALK_FUNC_DICT["unset_user_dict"] = pyopenjtalk.unset_user_dict
 
 
 class WorkerServer:
@@ -55,13 +56,16 @@ class WorkerServer:
             elif request_type == RequestType.PYOPENJTALK:
                 func_name = request.get("func")
                 assert isinstance(func_name, str)
-                func = PYOPENJTALK_FUNC_DICT[func_name]
-                args = request.get("args")
-                kwargs = request.get("kwargs")
-                assert isinstance(args, list)
-                assert isinstance(kwargs, dict)
-                ret = func(*args, **kwargs)
-                response = {"success": True, "return": ret}
+                if func_name not in PYOPENJTALK_FUNC_DICT:
+                    response = {"success": True, "return": None}
+                else:
+                    func = PYOPENJTALK_FUNC_DICT[func_name]
+                    args = request.get("args")
+                    kwargs = request.get("kwargs")
+                    assert isinstance(args, list)
+                    assert isinstance(kwargs, dict)
+                    ret = func(*args, **kwargs)
+                    response = {"success": True, "return": ret}
             else:
                 # NOT REACHED
                 response = request
@@ -72,7 +76,7 @@ class WorkerServer:
         logger.info("start pyopenjtalk worker server")
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
             server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            server_socket.bind((socket.gethostname(), port))
+            server_socket.bind(("localhost", port))
             server_socket.listen()
             sockets = [server_socket]
             no_client_since = time.time()

--- a/style_bert_vits2/nlp/japanese/user_dict/__init__.py
+++ b/style_bert_vits2/nlp/japanese/user_dict/__init__.py
@@ -147,7 +147,10 @@ def update_dict(
             raise RuntimeError("辞書のコンパイル時にエラーが発生しました。")
 
         # コンパイル済み辞書の置き換え・読み込み
-        pyopenjtalk.unset_user_dict()
+        try:
+            pyopenjtalk.unset_user_dict()
+        except Exception:
+            pass  # pyopenjtalk 0.4+ では unset_user_dict が削除されている
         tmp_compiled_path.replace(compiled_dict_path)
         if compiled_dict_path.is_file():
             # pyopenjtalk.set_user_dict(str(compiled_dict_path.resolve(strict=True)))


### PR DESCRIPTION
## Summary
- Add `hasattr` check for `unset_user_dict()` which was removed in pyopenjtalk 0.4+
- Handle missing function names in worker server gracefully
- Change socket binding from `socket.gethostname()` to `"localhost"` for reliable connection on macOS
- Wrap `unset_user_dict()` call with try-except for backward compatibility

## Motivation
When running on macOS, `socket.gethostname()` can fail to resolve properly, causing connection errors in the pyopenjtalk worker. Additionally, newer versions of pyopenjtalk (0.4+) removed the `unset_user_dict()` method, causing `AttributeError`.

## Changes
| File | Change |
|---|---|
| `pyopenjtalk_worker/__init__.py` | `hasattr` check before calling `unset_user_dict()` |
| `pyopenjtalk_worker/worker_client.py` | `socket.gethostname()` → `"localhost"` |
| `pyopenjtalk_worker/worker_server.py` | `"localhost"` binding + missing func handling |
| `user_dict/__init__.py` | try-except wrapper for `unset_user_dict()` |

## Testing
Tested on macOS 14 (Apple Silicon M4) with pyopenjtalk 0.3.x and 0.4+.

These changes are backward-compatible and do not affect existing CUDA/Linux environments.