### PR TITLE
Fix: CPU/AMD GPU support and Windows Japanese-username setup

### DIFF
--- a/SETUP_WINDOWS_JP.md
+++ b/SETUP_WINDOWS_JP.md
@@ -1,0 +1,209 @@
+# Windows（日本語ユーザー名環境）向けセットアップ手順
+
+このドキュメントは、**ユーザー名に日本語が含まれるWindows環境**（例：`C:\Users\川上貴大\`）での
+Style-Bert-VITS2 の環境構築手順をまとめたものです。
+
+## 動作確認済み環境
+
+| 項目 | 内容 |
+|------|------|
+| OS | Windows 11 Pro |
+| GPU | AMD Radeon（NVIDIA GPU なし → CPU推論） |
+| Python | 3.10.11（`C:\Python310` にインストール） |
+| PyTorch | 2.3.1+cpu |
+| transformers | 4.57.x |
+
+---
+
+## クイックスタート（スクリプト実行）
+
+PowerShell を開き、以下を実行するだけで環境構築が完了します。
+
+```powershell
+cd C:\Sbv2
+PowerShell -ExecutionPolicy Bypass -File setup_windows_jp.ps1
+```
+
+デフォルト音声モデル（jvnv-F1-jp 等）のダウンロードをスキップする場合：
+
+```powershell
+PowerShell -ExecutionPolicy Bypass -File setup_windows_jp.ps1 -SkipModels
+```
+
+完了後は以下で Web UI を起動できます：
+
+```powershell
+.\venv\Scripts\python.exe app.py
+```
+
+ブラウザで `http://127.0.0.1:7860` を開いてください。
+
+---
+
+## 手動セットアップ手順
+
+スクリプトを使わず手動で構築する場合の手順です。
+
+### 1. Visual C++ 2015-2022 Redistributable のインストール
+
+PyTorch が依存する `fbgemm.dll` を読み込むために必要です。
+
+```powershell
+winget install Microsoft.VCRedist.2015+.x64 --accept-package-agreements --accept-source-agreements
+```
+
+### 2. Python 3.10 を ASCII パスにインストール
+
+**重要**: uv や pyenv が Python を自動インストールする場合、`C:\Users\川上貴大\AppData\Roaming\uv\python\...`
+のような日本語を含むパスに配置されます。
+このパスを venv の `pyvenv.cfg` に記録すると、一部の PowerShell 環境で Python が起動できなくなります。
+
+日本語を含まない `C:\Python310` に直接インストールします。
+
+```powershell
+winget install Python.Python.3.10 --location C:\Python310 --accept-package-agreements --accept-source-agreements
+```
+
+インストール確認：
+
+```powershell
+C:\Python310\python.exe --version
+# Python 3.10.11
+```
+
+### 3. uv のインストール
+
+```powershell
+C:\Python310\python.exe -m pip install uv
+```
+
+### 4. 仮想環境の作成
+
+`C:\Python310` を使って venv を作成します（uv は使わず標準 venv モジュールを使用）。
+
+```powershell
+cd C:\Sbv2
+C:\Python310\python.exe -m venv venv
+```
+
+`venv\pyvenv.cfg` を開き、`home = C:\Python310` になっていることを確認してください。
+
+### 5. CPU 用 PyTorch のインストール
+
+NVIDIA GPU がない環境では CPU 版 PyTorch を使用します。
+AMD GPU でも CUDA は使えないため、CPU 推論になります（音声合成のみであれば実用的な速度で動作します）。
+
+```powershell
+uv pip install --python .\venv\Scripts\python.exe `
+    "torch==2.3.1" "torchaudio==2.3.1" `
+    --index-url https://download.pytorch.org/whl/cpu
+```
+
+### 6. 依存パッケージのインストール
+
+`requirements.txt` をそのまま使用すると以下の問題が発生します。
+
+| パッケージ | 問題 | 対処 |
+|-----------|------|------|
+| `faster-whisper==0.10.1` | `av` パッケージのビルドが Windows / Python 3.10 で失敗 | バージョン指定を外して最新版（1.2.1+）を使用 |
+| `torch<2.4` / `torchaudio<2.4` | CUDA 版がデフォルトで選択される | 先に CPU 版をインストール済みのため除外 |
+
+以下の手順でインストールします。
+
+```powershell
+# torch/torchaudio/faster-whisper を除いた requirements をインストール
+(Get-Content requirements.txt | Where-Object { $_ -notmatch '^\s*(torch|torchaudio|faster-whisper)' }) `
+    | Out-File requirements-custom.txt -Encoding utf8
+uv pip install --python .\venv\Scripts\python.exe -r requirements-custom.txt
+
+# faster-whisper は最新版（av のビルド不要）
+uv pip install --python .\venv\Scripts\python.exe faster-whisper
+
+# soxr: transformers 4.57+ が必要とするが requirements.txt に未記載
+uv pip install --python .\venv\Scripts\python.exe soxr
+
+# transformers: torch 2.3.1 と互換性のある 4.x 系に固定
+uv pip install --python .\venv\Scripts\python.exe "transformers>=4.40,<5.0"
+```
+
+### 7. モデルのダウンロード
+
+```powershell
+# BERT モデル・事前学習モデル・デフォルト音声モデルをダウンロード
+.\venv\Scripts\python.exe initialize.py
+
+# デフォルト音声モデルをスキップする場合（ダウンロード容量を節約）
+.\venv\Scripts\python.exe initialize.py --skip_default_models
+```
+
+---
+
+## Web UI の起動
+
+```powershell
+cd C:\Sbv2
+.\venv\Scripts\python.exe app.py
+```
+
+`http://127.0.0.1:7860` をブラウザで開いてください。
+
+---
+
+## よくあるエラーと対処法
+
+### `No Python at 'C:\Users\????\AppData\...'`
+
+**原因**: venv の `pyvenv.cfg` が日本語パスを参照しており、
+ターミナルのコードページがそのパスを解釈できない。
+
+**対処**: `venv` を削除し、手順 4 に従って `C:\Python310` を使って再作成する。
+
+```powershell
+Remove-Item -Recurse -Force .\venv
+C:\Python310\python.exe -m venv venv
+```
+
+### `Error loading "fbgemm.dll" or one of its dependencies`
+
+**原因**: Visual C++ 2015-2022 Redistributable が未インストール。
+
+**対処**: 手順 1 を実施する。
+
+### `[transformers] Disabling PyTorch because PyTorch >= 2.4 is required`
+
+**原因**: transformers 5.x は torch 2.4+ を要求するが、torch 2.3.1 が入っている。
+
+**対処**: transformers を 4.x 系に固定する。
+
+```powershell
+uv pip install --python .\venv\Scripts\python.exe "transformers>=4.40,<5.0"
+```
+
+### `ModuleNotFoundError: No module named 'soxr'`
+
+**対処**:
+```powershell
+uv pip install --python .\venv\Scripts\python.exe soxr
+```
+
+### `モデルが見つかりませんでした。model_assets にモデルを置いてください`
+
+**原因**: 音声モデルがダウンロードされていない（`--skip_default_models` を使用した場合など）。
+
+**対処**: `initialize.py` を引数なしで実行してサンプルモデルをダウンロードするか、
+自前のモデルを `model_assets/<モデル名>/` に配置する。
+
+```powershell
+.\venv\Scripts\python.exe initialize.py
+```
+
+---
+
+## 補足：GPU について
+
+このセットアップは **CPU 推論専用**です。
+
+- NVIDIA GPU（CUDA 対応）がある場合は、`torch` を CUDA 版に置き換えてください。
+  元の `requirements.txt` の手順（`cu118` インデックス URL）が使えます。
+- AMD GPU では Windows 上での ROCm サポートが限定的なため、CPU 推論を推奨します。
+  onnxruntime-directml（自動インストール済み）を使った ONNX 推論も選択肢の一つです。

--- a/SETUP_WINDOWS_JP.md
+++ b/SETUP_WINDOWS_JP.md
@@ -10,7 +10,7 @@ Style-Bert-VITS2 の環境構築手順をまとめたものです。
 | OS | Windows 11 Pro |
 | GPU | AMD Radeon（NVIDIA GPU なし → CPU推論） |
 | Python | 3.10.11（`C:\Python310` にインストール） |
-| PyTorch | 2.3.1+cpu |
+| PyTorch | 2.6.0+cpu |
 | transformers | 4.57.x |
 
 ---
@@ -95,7 +95,7 @@ AMD GPU でも CUDA は使えないため、CPU 推論になります（音声�
 
 ```powershell
 uv pip install --python .\venv\Scripts\python.exe `
-    "torch==2.3.1" "torchaudio==2.3.1" `
+    "torch==2.6.0" "torchaudio==2.6.0" `
     --index-url https://download.pytorch.org/whl/cpu
 ```
 
@@ -122,7 +122,7 @@ uv pip install --python .\venv\Scripts\python.exe faster-whisper
 # soxr: transformers 4.57+ が必要とするが requirements.txt に未記載
 uv pip install --python .\venv\Scripts\python.exe soxr
 
-# transformers: torch 2.3.1 と互換性のある 4.x 系に固定
+# transformers: 4.x 系（torch 2.6 との互換性あり、CVE-2025-32434 セキュリティチェック対応済み）
 uv pip install --python .\venv\Scripts\python.exe "transformers>=4.40,<5.0"
 ```
 

--- a/gradio_tabs/dataset.py
+++ b/gradio_tabs/dataset.py
@@ -1,8 +1,12 @@
 import gradio as gr
+import torch
 
 from style_bert_vits2.constants import GRADIO_THEME
 from style_bert_vits2.logging import logger
 from style_bert_vits2.utils.subprocess import run_script_with_log
+
+_CUDA_AVAILABLE = torch.cuda.is_available()
+_DEFAULT_COMPUTE_TYPE = "bfloat16" if _CUDA_AVAILABLE else "int8"
 
 
 def do_slice(
@@ -202,7 +206,7 @@ def create_dataset_app() -> gr.Blocks:
                         "float32",
                     ],
                     label="計算精度",
-                    value="bfloat16",
+                    value=_DEFAULT_COMPUTE_TYPE,
                     visible=True,
                 )
                 batch_size = gr.Slider(

--- a/requirements-custom.txt
+++ b/requirements-custom.txt
@@ -1,0 +1,30 @@
+﻿accelerate
+cmudict
+cn2an
+g2p_en
+GPUtil
+gradio>=4.32
+jieba
+librosa==0.9.2
+loguru
+nltk<=3.8.1
+num2words
+numpy<2
+onnx
+onnxconverter-common
+onnxruntime
+onnxruntime-directml; sys_platform == 'win32'
+onnxruntime-gpu; sys_platform != 'darwin'
+onnxsim-prebuilt
+protobuf==4.25
+psutil
+punctuators
+pyannote.audio>=3.1.0
+pyloudnorm
+pyopenjtalk-dict
+pypinyin
+pyworld-prebuilt
+stable_ts
+tensorboard
+transformers
+umap-learn

--- a/setup_windows_jp.ps1
+++ b/setup_windows_jp.ps1
@@ -1,0 +1,192 @@
+# Style-Bert-VITS2 Windows Setup Script
+# Supports Japanese username environments (e.g. C:\Users\川上貴大\...)
+# CPU-only mode (no NVIDIA GPU required)
+#
+# Usage:
+#   PowerShell -ExecutionPolicy Bypass -File setup_windows_jp.ps1
+#
+# Options:
+#   -SkipModels    Skip downloading default voice models (jvnv-F1-jp etc.)
+#   -SkipVC        Skip Visual C++ Redistributable check/install
+
+param(
+    [switch]$SkipModels,
+    [switch]$SkipVC
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $ScriptDir
+
+function Write-Step { param([string]$msg) Write-Host "`n=== $msg ===" -ForegroundColor Cyan }
+function Write-OK   { param([string]$msg) Write-Host "[OK] $msg" -ForegroundColor Green }
+function Write-Warn { param([string]$msg) Write-Host "[WARN] $msg" -ForegroundColor Yellow }
+function Write-Fail { param([string]$msg) Write-Host "[FAIL] $msg" -ForegroundColor Red }
+
+# ---------------------------------------------------------------------------
+# Step 1: Visual C++ 2015-2022 Redistributable
+# ---------------------------------------------------------------------------
+Write-Step "Visual C++ 2015-2022 Redistributable"
+
+if (-not $SkipVC) {
+    $vcKey = "HKLM:\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64"
+    $vcInstalled = (Test-Path $vcKey) -and ((Get-ItemProperty $vcKey -ErrorAction SilentlyContinue).Installed -eq 1)
+
+    if ($vcInstalled) {
+        Write-OK "Already installed"
+    } else {
+        Write-Host "Installing Visual C++ Redistributable..."
+        winget install Microsoft.VCRedist.2015+.x64 --accept-package-agreements --accept-source-agreements
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "winget install failed (exit $LASTEXITCODE). Continuing anyway."
+        } else {
+            Write-OK "Installed"
+        }
+    }
+} else {
+    Write-Warn "Skipped (--SkipVC)"
+}
+
+# ---------------------------------------------------------------------------
+# Step 2: Python 3.10 at ASCII path (C:\Python310)
+# ---------------------------------------------------------------------------
+Write-Step "Python 3.10 at C:\Python310"
+
+$Python310 = "C:\Python310\python.exe"
+
+if (Test-Path $Python310) {
+    $ver = & $Python310 --version 2>&1
+    Write-OK "$ver found at $Python310"
+} else {
+    Write-Host "Python 3.10 not found at C:\Python310. Installing via winget..."
+    winget install Python.Python.3.10 --location C:\Python310 --accept-package-agreements --accept-source-agreements
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $Python310)) {
+        Write-Fail "Failed to install Python 3.10. Please install manually to C:\Python310"
+        exit 1
+    }
+    Write-OK "Python 3.10 installed"
+}
+
+# ---------------------------------------------------------------------------
+# Step 3: uv package manager
+# ---------------------------------------------------------------------------
+Write-Step "uv package manager"
+
+$uvCmd = Get-Command uv -ErrorAction SilentlyContinue
+if ($uvCmd) {
+    Write-OK "uv $(uv --version) already installed"
+} else {
+    Write-Host "Installing uv..."
+    & $Python310 -m pip install uv --quiet
+    if ($LASTEXITCODE -ne 0) { Write-Fail "pip install uv failed"; exit 1 }
+    Write-OK "uv installed"
+}
+
+# ---------------------------------------------------------------------------
+# Step 4: Virtual environment
+# ---------------------------------------------------------------------------
+Write-Step "Virtual environment (venv)"
+
+$VenvPython = ".\venv\Scripts\python.exe"
+$PyvenvCfg  = ".\venv\pyvenv.cfg"
+
+$needRebuild = $false
+if (Test-Path $PyvenvCfg) {
+    $home = (Get-Content $PyvenvCfg | Select-String "^home").ToString()
+    if ($home -notmatch "C:\\Python310") {
+        Write-Warn "Existing venv points to wrong Python ($home). Rebuilding..."
+        Remove-Item -Recurse -Force .\venv
+        $needRebuild = $true
+    } else {
+        Write-OK "Existing venv OK"
+    }
+} else {
+    $needRebuild = $true
+}
+
+if ($needRebuild) {
+    Write-Host "Creating venv with C:\Python310..."
+    & $Python310 -m venv venv
+    if ($LASTEXITCODE -ne 0) { Write-Fail "venv creation failed"; exit 1 }
+    Write-OK "venv created"
+}
+
+# ---------------------------------------------------------------------------
+# Step 5: CPU PyTorch
+# ---------------------------------------------------------------------------
+Write-Step "PyTorch (CPU)"
+
+$torchOk = & $VenvPython -c "import torch; print(torch.__version__)" 2>&1
+if ($torchOk -match "2\.[34]") {
+    Write-OK "torch $torchOk already installed"
+} else {
+    Write-Host "Installing torch 2.3.1+cpu and torchaudio..."
+    uv pip install --python $VenvPython `
+        "torch==2.3.1" "torchaudio==2.3.1" `
+        --index-url https://download.pytorch.org/whl/cpu
+    if ($LASTEXITCODE -ne 0) { Write-Fail "PyTorch install failed"; exit 1 }
+    Write-OK "torch 2.3.1+cpu installed"
+}
+
+# ---------------------------------------------------------------------------
+# Step 6: Requirements (with Windows/Japanese-env workarounds)
+# ---------------------------------------------------------------------------
+Write-Step "Python dependencies"
+
+# Build a filtered requirements list: exclude torch/torchaudio (already installed)
+# and faster-whisper (pinned version fails to build 'av' on Windows Python 3.10)
+$reqs = Get-Content requirements.txt |
+    Where-Object { $_ -notmatch '^\s*(torch|torchaudio|faster-whisper)' }
+$reqs | Out-File -FilePath requirements-custom.txt -Encoding utf8
+
+Write-Host "Installing requirements (excluding torch/torchaudio/faster-whisper)..."
+uv pip install --python $VenvPython -r requirements-custom.txt
+if ($LASTEXITCODE -ne 0) { Write-Fail "requirements install failed"; exit 1 }
+
+# faster-whisper: use latest version (has prebuilt av wheels for Windows)
+Write-Host "Installing faster-whisper (latest)..."
+uv pip install --python $VenvPython faster-whisper
+if ($LASTEXITCODE -ne 0) { Write-Fail "faster-whisper install failed"; exit 1 }
+
+# soxr: required by transformers 4.57+ but not listed in requirements
+Write-Host "Installing soxr..."
+uv pip install --python $VenvPython soxr
+if ($LASTEXITCODE -ne 0) { Write-Warn "soxr install failed (non-critical)" }
+
+# transformers: pin to 4.x to stay compatible with torch 2.3.1
+Write-Host "Pinning transformers to 4.x (compatible with torch 2.3.1)..."
+uv pip install --python $VenvPython "transformers>=4.40,<5.0"
+if ($LASTEXITCODE -ne 0) { Write-Fail "transformers install failed"; exit 1 }
+
+Write-OK "All dependencies installed"
+
+# ---------------------------------------------------------------------------
+# Step 7: Download models
+# ---------------------------------------------------------------------------
+Write-Step "Download BERT / pretrained models"
+
+$initArgs = @()
+if ($SkipModels) {
+    $initArgs += "--skip_default_models"
+    Write-Warn "Skipping default voice models (--SkipModels)"
+}
+
+& $VenvPython initialize.py @initArgs
+if ($LASTEXITCODE -ne 0) { Write-Fail "initialize.py failed"; exit 1 }
+Write-OK "Models downloaded"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "============================================" -ForegroundColor Green
+Write-Host " Setup complete!" -ForegroundColor Green
+Write-Host "============================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "To start the Web UI, run:"
+Write-Host "  .\venv\Scripts\python.exe app.py" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "Then open http://127.0.0.1:7860 in your browser."
+Write-Host ""

--- a/setup_windows_jp.ps1
+++ b/setup_windows_jp.ps1
@@ -119,15 +119,15 @@ if ($needRebuild) {
 Write-Step "PyTorch (CPU)"
 
 $torchOk = & $VenvPython -c "import torch; print(torch.__version__)" 2>&1
-if ($torchOk -match "2\.[34]") {
+if ($torchOk -match "2\.[6-9]") {
     Write-OK "torch $torchOk already installed"
 } else {
-    Write-Host "Installing torch 2.3.1+cpu and torchaudio..."
+    Write-Host "Installing torch 2.6.0+cpu and torchaudio..."
     uv pip install --python $VenvPython `
-        "torch==2.3.1" "torchaudio==2.3.1" `
+        "torch==2.6.0" "torchaudio==2.6.0" `
         --index-url https://download.pytorch.org/whl/cpu
     if ($LASTEXITCODE -ne 0) { Write-Fail "PyTorch install failed"; exit 1 }
-    Write-OK "torch 2.3.1+cpu installed"
+    Write-OK "torch 2.6.0+cpu installed"
 }
 
 # ---------------------------------------------------------------------------

--- a/style_bert_vits2/models/utils/checkpoints.py
+++ b/style_bert_vits2/models/utils/checkpoints.py
@@ -32,7 +32,8 @@ def load_checkpoint(
     """
 
     assert os.path.isfile(checkpoint_path)
-    checkpoint_dict = torch.load(checkpoint_path, map_location=device)
+    # weights_only=False: training checkpoints contain optimizer state with non-tensor types
+    checkpoint_dict = torch.load(checkpoint_path, map_location=device, weights_only=False)
     iteration = checkpoint_dict["iteration"]
     learning_rate = checkpoint_dict["learning_rate"]
     logger.info(

--- a/style_bert_vits2/utils/subprocess.py
+++ b/style_bert_vits2/utils/subprocess.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from typing import Any, Callable
@@ -21,12 +22,16 @@ def run_script_with_log(
     """
 
     logger.info(f"Running: {' '.join(cmd)}")
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
     result = subprocess.run(
         [sys.executable] + cmd,
         stdout=SAFE_STDOUT,
         stderr=subprocess.PIPE,
         text=True,
         encoding="utf-8",
+        errors="replace",
+        env=env,
         check=False,
     )
     if result.returncode != 0:

--- a/train_ms.py
+++ b/train_ms.py
@@ -37,17 +37,18 @@ from style_bert_vits2.nlp.symbols import SYMBOLS
 from style_bert_vits2.utils.stdout_wrapper import SAFE_STDOUT
 
 
-torch.backends.cuda.matmul.allow_tf32 = True
-torch.backends.cudnn.allow_tf32 = (
-    True  # If encontered training problem,please try to disable TF32.
-)
+if torch.cuda.is_available():
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = (
+        True  # If encontered training problem,please try to disable TF32.
+    )
+    torch.backends.cuda.sdp_kernel("flash")
+    torch.backends.cuda.enable_flash_sdp(True)
+    torch.backends.cuda.enable_mem_efficient_sdp(
+        True
+    )  # Not available if torch version is lower than 2.0
+    torch.backends.cuda.enable_math_sdp(True)
 torch.set_float32_matmul_precision("medium")
-torch.backends.cuda.sdp_kernel("flash")
-torch.backends.cuda.enable_flash_sdp(True)
-torch.backends.cuda.enable_mem_efficient_sdp(
-    True
-)  # Not available if torch version is lower than 2.0
-torch.backends.cuda.enable_math_sdp(True)
 
 config = get_config()
 global_step = 0
@@ -129,6 +130,8 @@ def run():
     backend = "nccl"
     if platform.system() == "Windows":
         backend = "gloo"  # If Windows,switch to gloo backend.
+        # CPU-only PyTorch builds on Windows don't include libuv; force legacy TCPStore
+        os.environ.setdefault("USE_LIBUV", "0")
     dist.init_process_group(
         backend=backend,
         init_method="env://",
@@ -206,7 +209,9 @@ def run():
         )
 
     torch.manual_seed(hps.train.seed)
-    torch.cuda.set_device(local_rank)
+    if torch.cuda.is_available():
+        torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank) if torch.cuda.is_available() else torch.device("cpu")
 
     global global_step
     writer = None
@@ -294,7 +299,7 @@ def run():
             3,
             0.1,
             gin_channels=hps.model.gin_channels if hps.data.n_speakers != 0 else 0,
-        ).cuda(local_rank)
+        ).to(device)
     if hps.model.use_spk_conditioned_encoder is True:
         if hps.data.n_speakers == 0:
             raise ValueError(
@@ -333,7 +338,7 @@ def run():
         use_spectral_norm=hps.model.use_spectral_norm,
         gin_channels=hps.model.gin_channels,
         slm=hps.model.slm,
-    ).cuda(local_rank)
+    ).to(device)
 
     if getattr(hps.train, "freeze_ZH_bert", False):
         logger.info("Freezing ZH bert encoder !!!")
@@ -359,7 +364,7 @@ def run():
         for param in net_g.dec.parameters():
             param.requires_grad = False
 
-    net_d = MultiPeriodDiscriminator(hps.model.use_spectral_norm).cuda(local_rank)
+    net_d = MultiPeriodDiscriminator(hps.model.use_spectral_norm).to(device)
     optim_g = torch.optim.AdamW(
         filter(lambda p: p.requires_grad, net_g.parameters()),
         hps.train.learning_rate,
@@ -381,13 +386,12 @@ def run():
         )
     else:
         optim_dur_disc = None
-    net_g = DDP(net_g, device_ids=[local_rank])
-    net_d = DDP(net_d, device_ids=[local_rank])
+    _ddp_kwargs = {"device_ids": [local_rank]} if torch.cuda.is_available() else {}
+    net_g = DDP(net_g, **_ddp_kwargs)
+    net_d = DDP(net_d, **_ddp_kwargs)
     dur_resume_lr = None
     if net_dur_disc is not None:
-        net_dur_disc = DDP(
-            net_dur_disc, device_ids=[local_rank], find_unused_parameters=True
-        )
+        net_dur_disc = DDP(net_dur_disc, find_unused_parameters=True, **_ddp_kwargs)
 
     if utils.is_resuming(model_dir):
         if net_dur_disc is not None:
@@ -606,6 +610,7 @@ def train_and_evaluate(
     optim_g, optim_d, optim_dur_disc = optims
     scheduler_g, scheduler_d, scheduler_dur_disc = schedulers
     train_loader, eval_loader = loaders
+    device = torch.device("cuda", local_rank) if torch.cuda.is_available() else torch.device("cpu")
     if writers is not None:
         writer, writer_eval = writers
 
@@ -637,22 +642,16 @@ def train_and_evaluate(
                 - net_g.module.noise_scale_delta * global_step
             )
             net_g.module.current_mas_noise_scale = max(current_mas_noise_scale, 0.0)
-        x, x_lengths = x.cuda(local_rank, non_blocking=True), x_lengths.cuda(
-            local_rank, non_blocking=True
-        )
-        spec, spec_lengths = spec.cuda(
-            local_rank, non_blocking=True
-        ), spec_lengths.cuda(local_rank, non_blocking=True)
-        y, y_lengths = y.cuda(local_rank, non_blocking=True), y_lengths.cuda(
-            local_rank, non_blocking=True
-        )
-        speakers = speakers.cuda(local_rank, non_blocking=True)
-        tone = tone.cuda(local_rank, non_blocking=True)
-        language = language.cuda(local_rank, non_blocking=True)
-        bert = bert.cuda(local_rank, non_blocking=True)
-        ja_bert = ja_bert.cuda(local_rank, non_blocking=True)
-        en_bert = en_bert.cuda(local_rank, non_blocking=True)
-        style_vec = style_vec.cuda(local_rank, non_blocking=True)
+        x, x_lengths = x.to(device, non_blocking=True), x_lengths.to(device, non_blocking=True)
+        spec, spec_lengths = spec.to(device, non_blocking=True), spec_lengths.to(device, non_blocking=True)
+        y, y_lengths = y.to(device, non_blocking=True), y_lengths.to(device, non_blocking=True)
+        speakers = speakers.to(device, non_blocking=True)
+        tone = tone.to(device, non_blocking=True)
+        language = language.to(device, non_blocking=True)
+        bert = bert.to(device, non_blocking=True)
+        ja_bert = ja_bert.to(device, non_blocking=True)
+        en_bert = en_bert.to(device, non_blocking=True)
+        style_vec = style_vec.to(device, non_blocking=True)
 
         with autocast(enabled=hps.train.bf16_run, dtype=torch.bfloat16):
             (
@@ -887,7 +886,8 @@ def train_and_evaluate(
     # 本家ではこれをスピードアップのために消すと書かれていたので、一応消してみる
     # と思ったけどメモリ使用量が減るかもしれないのでつけてみる
     gc.collect()
-    torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     if pbar is None and rank == 0:
         logger.info(f"====> Epoch: {epoch}, step: {global_step}")
 
@@ -896,6 +896,7 @@ def evaluate(hps, generator, eval_loader, writer_eval):
     generator.eval()
     image_dict = {}
     audio_dict = {}
+    device = next(generator.parameters()).device
     print()
     logger.info("Evaluating ...")
     with torch.no_grad():
@@ -914,16 +915,16 @@ def evaluate(hps, generator, eval_loader, writer_eval):
             en_bert,
             style_vec,
         ) in enumerate(eval_loader):
-            x, x_lengths = x.cuda(), x_lengths.cuda()
-            spec, spec_lengths = spec.cuda(), spec_lengths.cuda()
-            y, y_lengths = y.cuda(), y_lengths.cuda()
-            speakers = speakers.cuda()
-            bert = bert.cuda()
-            ja_bert = ja_bert.cuda()
-            en_bert = en_bert.cuda()
-            tone = tone.cuda()
-            language = language.cuda()
-            style_vec = style_vec.cuda()
+            x, x_lengths = x.to(device), x_lengths.to(device)
+            spec, spec_lengths = spec.to(device), spec_lengths.to(device)
+            y, y_lengths = y.to(device), y_lengths.to(device)
+            speakers = speakers.to(device)
+            bert = bert.to(device)
+            ja_bert = ja_bert.to(device)
+            en_bert = en_bert.to(device)
+            tone = tone.to(device)
+            language = language.to(device)
+            style_vec = style_vec.to(device)
             for use_sdp in [True, False]:
                 y_hat, attn, mask, *_ = generator.module.infer(
                     x,

--- a/train_ms_jp_extra.py
+++ b/train_ms_jp_extra.py
@@ -38,17 +38,18 @@ from style_bert_vits2.nlp.symbols import SYMBOLS
 from style_bert_vits2.utils.stdout_wrapper import SAFE_STDOUT
 
 
-torch.backends.cuda.matmul.allow_tf32 = True
-torch.backends.cudnn.allow_tf32 = (
-    True  # If encontered training problem,please try to disable TF32.
-)
+if torch.cuda.is_available():
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = (
+        True  # If encontered training problem,please try to disable TF32.
+    )
+    torch.backends.cuda.sdp_kernel("flash")
+    torch.backends.cuda.enable_flash_sdp(True)
+    torch.backends.cuda.enable_mem_efficient_sdp(
+        True
+    )  # Not available if torch version is lower than 2.0
 torch.set_num_threads(1)
 torch.set_float32_matmul_precision("medium")
-torch.backends.cuda.sdp_kernel("flash")
-torch.backends.cuda.enable_flash_sdp(True)
-torch.backends.cuda.enable_mem_efficient_sdp(
-    True
-)  # Not available if torch version is lower than 2.0
 
 config = get_config()
 global_step = 0
@@ -130,6 +131,8 @@ def run():
     backend = "nccl"
     if platform.system() == "Windows":
         backend = "gloo"  # If Windows,switch to gloo backend.
+        # CPU-only PyTorch builds on Windows don't include libuv; force legacy TCPStore
+        os.environ.setdefault("USE_LIBUV", "0")
     dist.init_process_group(
         backend=backend,
         init_method="env://",
@@ -207,7 +210,9 @@ def run():
         )
 
     torch.manual_seed(hps.train.seed)
-    torch.cuda.set_device(local_rank)
+    if torch.cuda.is_available():
+        torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank) if torch.cuda.is_available() else torch.device("cpu")
 
     global global_step
     writer = None
@@ -299,13 +304,13 @@ def run():
             3,
             0.1,
             gin_channels=hps.model.gin_channels if hps.data.n_speakers != 0 else 0,
-        ).cuda(local_rank)
+        ).to(device)
     else:
         net_dur_disc = None
     if hps.model.use_wavlm_discriminator is True:
         net_wd = WavLMDiscriminator(
             hps.model.slm.hidden, hps.model.slm.nlayers, hps.model.slm.initial_channel
-        ).cuda(local_rank)
+        ).to(device)
     else:
         net_wd = None
     if hps.model.use_spk_conditioned_encoder is True:
@@ -346,7 +351,7 @@ def run():
         use_spectral_norm=hps.model.use_spectral_norm,
         gin_channels=hps.model.gin_channels,
         slm=hps.model.slm,
-    ).cuda(local_rank)
+    ).to(device)
     if getattr(hps.train, "freeze_JP_bert", False):
         logger.info("Freezing (JP) bert encoder !!!")
         for param in net_g.enc_p.bert_proj.parameters():
@@ -361,7 +366,7 @@ def run():
         for param in net_g.dec.parameters():
             param.requires_grad = False
 
-    net_d = MultiPeriodDiscriminator(hps.model.use_spectral_norm).cuda(local_rank)
+    net_d = MultiPeriodDiscriminator(hps.model.use_spectral_norm).to(device)
     optim_g = torch.optim.AdamW(
         filter(lambda p: p.requires_grad, net_g.parameters()),
         hps.train.learning_rate,
@@ -392,28 +397,13 @@ def run():
         )
     else:
         optim_wd = None
-    net_g = DDP(
-        net_g,
-        device_ids=[local_rank],
-        # bucket_cap_mb=512
-    )
-    net_d = DDP(
-        net_d,
-        device_ids=[local_rank],
-        # bucket_cap_mb=512
-    )
+    _ddp_kwargs = {"device_ids": [local_rank]} if torch.cuda.is_available() else {}
+    net_g = DDP(net_g, **_ddp_kwargs)
+    net_d = DDP(net_d, **_ddp_kwargs)
     if net_dur_disc is not None:
-        net_dur_disc = DDP(
-            net_dur_disc,
-            device_ids=[local_rank],
-            # bucket_cap_mb=512,
-        )
+        net_dur_disc = DDP(net_dur_disc, **_ddp_kwargs)
     if net_wd is not None:
-        net_wd = DDP(
-            net_wd,
-            device_ids=[local_rank],
-            #  bucket_cap_mb=512
-        )
+        net_wd = DDP(net_wd, **_ddp_kwargs)
 
     if utils.is_resuming(model_dir):
         if net_dur_disc is not None:
@@ -545,7 +535,7 @@ def run():
             net_wd,
             hps.data.sampling_rate,
             hps.model.slm.sr,
-        ).to(local_rank)
+        ).to(device)
     else:
         scheduler_wd = None
         wl = None
@@ -697,6 +687,8 @@ def train_and_evaluate(
     if writers is not None:
         writer, writer_eval = writers
 
+    device = torch.device("cuda", local_rank) if torch.cuda.is_available() else torch.device("cpu")
+
     # train_loader.batch_sampler.set_epoch(epoch)
     global global_step
 
@@ -725,20 +717,14 @@ def train_and_evaluate(
                 - net_g.module.noise_scale_delta * global_step
             )
             net_g.module.current_mas_noise_scale = max(current_mas_noise_scale, 0.0)
-        x, x_lengths = x.cuda(local_rank, non_blocking=True), x_lengths.cuda(
-            local_rank, non_blocking=True
-        )
-        spec, spec_lengths = spec.cuda(
-            local_rank, non_blocking=True
-        ), spec_lengths.cuda(local_rank, non_blocking=True)
-        y, y_lengths = y.cuda(local_rank, non_blocking=True), y_lengths.cuda(
-            local_rank, non_blocking=True
-        )
-        speakers = speakers.cuda(local_rank, non_blocking=True)
-        tone = tone.cuda(local_rank, non_blocking=True)
-        language = language.cuda(local_rank, non_blocking=True)
-        bert = bert.cuda(local_rank, non_blocking=True)
-        style_vec = style_vec.cuda(local_rank, non_blocking=True)
+        x, x_lengths = x.to(device, non_blocking=True), x_lengths.to(device, non_blocking=True)
+        spec, spec_lengths = spec.to(device, non_blocking=True), spec_lengths.to(device, non_blocking=True)
+        y, y_lengths = y.to(device, non_blocking=True), y_lengths.to(device, non_blocking=True)
+        speakers = speakers.to(device, non_blocking=True)
+        tone = tone.to(device, non_blocking=True)
+        language = language.to(device, non_blocking=True)
+        bert = bert.to(device, non_blocking=True)
+        style_vec = style_vec.to(device, non_blocking=True)
 
         with autocast(enabled=hps.train.bf16_run, dtype=torch.bfloat16):
             (
@@ -1041,7 +1027,8 @@ def train_and_evaluate(
             pbar.update()
 
     gc.collect()
-    torch.cuda.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     if pbar is None and rank == 0:
         logger.info(f"====> Epoch: {epoch}, step: {global_step}")
 
@@ -1050,6 +1037,7 @@ def evaluate(hps, generator, eval_loader, writer_eval):
     generator.eval()
     image_dict = {}
     audio_dict = {}
+    device = next(generator.parameters()).device
     print()
     logger.info("Evaluating ...")
     with torch.no_grad():
@@ -1066,14 +1054,14 @@ def evaluate(hps, generator, eval_loader, writer_eval):
             bert,
             style_vec,
         ) in enumerate(eval_loader):
-            x, x_lengths = x.cuda(), x_lengths.cuda()
-            spec, spec_lengths = spec.cuda(), spec_lengths.cuda()
-            y, y_lengths = y.cuda(), y_lengths.cuda()
-            speakers = speakers.cuda()
-            bert = bert.cuda()
-            tone = tone.cuda()
-            language = language.cuda()
-            style_vec = style_vec.cuda()
+            x, x_lengths = x.to(device), x_lengths.to(device)
+            spec, spec_lengths = spec.to(device), spec_lengths.to(device)
+            y, y_lengths = y.to(device), y_lengths.to(device)
+            speakers = speakers.to(device)
+            bert = bert.to(device)
+            tone = tone.to(device)
+            language = language.to(device)
+            style_vec = style_vec.to(device)
             for use_sdp in [True, False]:
                 y_hat, attn, mask, *_ = generator.module.infer(
                     x,

--- a/transcribe.py
+++ b/transcribe.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 from typing import Any, Optional
 
+import torch
 from torch.utils.data import Dataset
 from tqdm import tqdm
 
@@ -125,8 +126,10 @@ if __name__ == "__main__":
         "--language", type=str, default="ja", choices=["ja", "en", "zh"]
     )
     parser.add_argument("--model", type=str, default="large-v3")
-    parser.add_argument("--device", type=str, default="cuda")
-    parser.add_argument("--compute_type", type=str, default="bfloat16")
+    _default_device = "cuda" if torch.cuda.is_available() else "cpu"
+    _default_compute = "bfloat16" if torch.cuda.is_available() else "int8"
+    parser.add_argument("--device", type=str, default=_default_device)
+    parser.add_argument("--compute_type", type=str, default=_default_compute)
     parser.add_argument("--use_hf_whisper", action="store_true")
     parser.add_argument("--hf_repo_id", type=str, default="")
     parser.add_argument("--batch_size", type=int, default=16)
@@ -146,6 +149,13 @@ if __name__ == "__main__":
     language: str = args.language
     device: str = args.device
     compute_type: str = args.compute_type
+    # bfloat16/float16 are not supported by ctranslate2 on CPU
+    _cpu_incompatible = {"float16", "bfloat16", "int8_float16", "int8_bfloat16"}
+    if device == "cpu" and compute_type in _cpu_incompatible:
+        logger.warning(
+            f"compute_type '{compute_type}' is not supported on CPU. Falling back to 'int8'."
+        )
+        compute_type = "int8"
     batch_size: int = args.batch_size
     num_beams: int = args.num_beams
     no_repeat_ngram_size: int = args.no_repeat_ngram_size


### PR DESCRIPTION
## Summary

This PR adds support for running Style-Bert-VITS2 on Windows machines with AMD GPUs (no NVIDIA/CUDA) and Japanese usernames, and fixes several issues encountered during setup and training.

### Changes

**Training scripts (`train_ms.py`, `train_ms_jp_extra.py`)**
- Guard all CUDA calls behind `torch.cuda.is_available()` 窶・training now works on CPU-only machines
- Use `gloo` backend with `USE_LIBUV=0` on Windows (CPU PyTorch builds lack libuv)
- Replace all `.cuda(local_rank)` / `.to(local_rank)` calls with `.to(device)` where `device` is resolved at runtime
- Fix `DistributedDataParallel` initialization to omit `device_ids` when running on CPU
- Guard `torch.cuda.empty_cache()` calls

**`transcribe.py`**
- Auto-detect CUDA availability for default `--device` and `--compute_type` arguments
- Fall back to `int8` when CPU is used with an incompatible float16/bfloat16 compute type

**`gradio_tabs/dataset.py`**
- Same compute_type auto-detection for the WebUI transcription tab

**`style_bert_vits2/utils/subprocess.py`**
- Set `PYTHONIOENCODING=utf-8` in subprocess environment to prevent `UnicodeDecodeError` (Shift-JIS) on Japanese Windows

**`style_bert_vits2/models/utils/checkpoints.py`**
- Pass `weights_only=False` to `torch.load` 窶・PyTorch 2.6 changed the default to `True`, which breaks loading existing checkpoints containing custom classes

**`requirements-custom.txt`** (new)
- Filtered requirements file excluding `torch`, `torchaudio`, `faster-whisper` for use in CPU-only installs

**`setup_windows_jp.ps1`** + **`SETUP_WINDOWS_JP.md`** (new)
- Automated PowerShell setup script and manual guide for Windows + Japanese username environments
- Covers: VC++ runtime, Python 3.10 to ASCII path (`C:\Python310`), uv venv creation, CPU torch install, all known quirks

## Background

On Windows with a Japanese username (e.g. `C:\Users\蟾昜ｸ願ｲｴ螟ｧ\`), the standard setup fails because:
- `uv` installs Python to a path with Japanese characters, breaking venv resolution
- Subprocess encoding defaults to Shift-JIS on Japanese Windows
- PyTorch 2.6 tightened `torch.load` defaults (CVE-2025-32434), breaking model loading

On AMD GPU machines with no CUDA, all training scripts assumed CUDA unconditionally.

## Testing

Verified end-to-end on Windows 11 Pro with AMD Radeon GPU (CPU-only PyTorch 2.6.0+cpu):
- All 5 preprocessing steps complete successfully
- Training runs without errors (CPU, single process, gloo backend)
